### PR TITLE
Add static `.SystemMessage` component

### DIFF
--- a/dev/app.js
+++ b/dev/app.js
@@ -13,11 +13,13 @@ define([
     'components/rb-page-title/demo',
     'components/rb-ratio/demo',
     'components/rb-site/demo',
+    'components/rb-system-message/demo',
     'components/rb-text-control/demo',
     'rbx_style_guide'
 ], function (
     uiRouter, template, rbBadgeDemo, rbButtonDemo, rbDateTimeDemo, rbFooterDemo, rbHeaderDemo, rbLoadingDemo,
-    rbLoginFormDemo, rbMainDemo, rbPageHeaderDemo, rbPageTitleDemo, rbRatioDemo, rbSiteDemo, rbTextControlDemo, css
+    rbLoginFormDemo, rbMainDemo, rbPageHeaderDemo, rbPageTitleDemo, rbRatioDemo, rbSiteDemo, rbSystemMessage,
+    rbTextControlDemo, css
     ) {
     // @ngInject
     angular
@@ -35,6 +37,7 @@ define([
             rbPageTitleDemo.name,
             rbRatioDemo.name,
             rbSiteDemo.name,
+            rbSystemMessage.name,
             rbTextControlDemo.name
         ])
         .config(function ($stateProvider, $httpProvider) {

--- a/src/rb-system-message/demo/demo-ctrl.js
+++ b/src/rb-system-message/demo/demo-ctrl.js
@@ -1,0 +1,9 @@
+define([
+], function () {
+
+    // @ngInject
+    function demoCtrl ($rootScope, $state, $injector) {
+    }
+
+    return demoCtrl;
+});

--- a/src/rb-system-message/demo/demo-state.js
+++ b/src/rb-system-message/demo/demo-state.js
@@ -1,0 +1,15 @@
+define([
+    'html!./demo.tpl.html'
+], function (template) {
+
+    // @ngInject
+    function demoState ($stateProvider, $urlRouterProvider) {
+        $stateProvider.state('rb-system-message', {
+            url: '/rb-system-message',
+            controller: 'demo-rb-system-message-ctrl as demoCtrl',
+            template: template
+        });
+    }
+
+    return demoState;
+});

--- a/src/rb-system-message/demo/demo.tpl.html
+++ b/src/rb-system-message/demo/demo.tpl.html
@@ -1,0 +1,96 @@
+<h1 class="u-textHeading1">
+    .SystemMessage
+</h1>
+
+<h2 class="u-textHeading2">
+    No modifier
+</h2>
+
+<div class="SystemMessage">
+    <div class="SystemMessage-inner">
+        <div class="SystemMessage-body">
+            <h2 class="u-textHeading2">
+                Message title
+            </h2>
+            <p>
+                Add a message here about it and what not Nullam quis risus eget urna mollis ornare eu leo. Cras
+                justo odio, dapibus ac facilisis in, egestas eget.
+                <a href="mailto:test@example.com">test@example.com</a>
+            </p>
+        </div>
+        <div class="SystemMessage-details">
+            <h3 class="u-textBold u-textSmall">
+                Technical details
+            </h3>
+            <rb-text-control name="technical-details" type="textarea"></rb-text-control>
+        </div>
+        <div class="SystemMessage-action">
+            <rb-button size="small">
+                Message Dismiss
+            </rb-button>
+        </div>
+    </div>
+</div>
+
+<h2 class="u-textHeading2">
+    Danger modifier
+</h2>
+
+<div class="SystemMessage SystemMessage--danger">
+    <div class="SystemMessage-inner">
+        <div class="SystemMessage-body">
+            <h2 class="u-textHeading2">
+                Message title
+            </h2>
+            <p>
+                Add a message here about it and what not Nullam quis risus eget urna mollis ornare eu leo. Cras
+                justo odio, dapibus ac facilisis in, egestas eget.
+                <a href="mailto:test@example.com">test@example.com</a>
+            </p>
+        </div>
+        <div class="SystemMessage-details">
+            <h3 class="u-textBold u-textSmall">
+                Technical details
+            </h3>
+            <rb-text-control name="technical-details" type="textarea"></rb-text-control>
+        </div>
+        <div class="SystemMessage-action">
+            <rb-button size="small">
+                Message Dismiss
+            </rb-button>
+        </div>
+    </div>
+</div>
+
+<h2 class="u-textHeading2">
+    Positive modifier
+</h2>
+
+<div class="SystemMessage SystemMessage--positive">
+    <div class="SystemMessage-inner">
+        <div class="SystemMessage-body">
+            <h2 class="u-textHeading2">
+                Message title
+            </h2>
+            <p>
+                Add a message here about it and what not Nullam quis risus eget urna mollis ornare eu leo. Cras
+                justo odio, dapibus ac facilisis in, egestas eget.
+                <a href="mailto:test@example.com">test@example.com</a>
+            </p>
+        </div>
+        <div class="SystemMessage-details">
+            <h3 class="u-textBold u-textSmall">
+                Technical details
+            </h3>
+            <rb-text-control
+                name="technical-details"
+                type="textarea">
+            </rb-text-control>
+        </div>
+        <div class="SystemMessage-action">
+            <rb-button size="small">
+                Message Dismiss
+            </rb-button>
+        </div>
+    </div>
+</div>

--- a/src/rb-system-message/demo/index.js
+++ b/src/rb-system-message/demo/index.js
@@ -1,0 +1,14 @@
+define([
+    '../index.js',
+    './demo-ctrl',
+    './demo-state'
+], function (rbSystemMessage, demoCtrl, demoState) {
+    var demo = angular
+        .module('rb-system-message-demo', [
+            rbSystemMessage.name
+        ])
+        .config(demoState)
+        .controller('demo-rb-system-message-ctrl', demoCtrl);
+
+    return demo;
+});

--- a/src/rb-system-message/images/SystemMessage-background.svg
+++ b/src/rb-system-message/images/SystemMessage-background.svg
@@ -1,0 +1,1 @@
+<svg width="4" height="16" viewBox="0 0 4 16" xmlns="http://www.w3.org/2000/svg"><title>SystemMessage-background</title><path d="M0 16v-4h4v4H0zM0 0h4v10H0V0z" fill="#FCFCFC" fill-rule="evenodd"/></svg>

--- a/src/rb-system-message/index.js
+++ b/src/rb-system-message/index.js
@@ -1,0 +1,19 @@
+define([
+    './rb-system-message-directive',
+    './rb-system-message.css'
+], function (rbSystemMessageDirective, css) {
+    /**
+     * @ngdoc module
+     * @name rb-system-message
+     * @description
+     *
+     * rbSystemMessage
+     *
+     */
+    var rbSystemMessage = angular
+        .module('rb-system-message', [])
+        .directive('rbSystemMessage', rbSystemMessageDirective);
+
+    return rbSystemMessage;
+
+});

--- a/src/rb-system-message/rb-system-message-directive.js
+++ b/src/rb-system-message/rb-system-message-directive.js
@@ -1,0 +1,34 @@
+define([
+    'html!./rb-system-message.tpl.html'
+], function (template) {
+
+    /**
+     * @ngdoc directive
+     * @name rbSystemMessage
+     * @module rb-system-message
+     *
+     * @restrict E
+     *
+     * @description
+     *
+     * @usage
+     * <hljs lang="html">
+     *    <rb-system-message>
+     *     </rb-system-message>
+     * </hljs>
+     *
+     * @ngInject
+     */
+    function rbSystemMessageDirective () {
+
+        return {
+            scope: {
+            },
+            restrict: 'E',
+            replace: true,
+            template: template
+        };
+    }
+
+    return rbSystemMessageDirective;
+});

--- a/src/rb-system-message/rb-system-message.css
+++ b/src/rb-system-message/rb-system-message.css
@@ -1,0 +1,88 @@
+/** @define SystemMessage; use strict */
+
+/**
+ * The `.SystemMessage` component can be used for displaying low-level system error messages.
+ *
+ * Modifiers:
+ *
+ * - No modifier: displays a message with blue background.
+ * - `.SystemMessage--danger`: displays a message with red background.
+ * - `.SystemMessage--positive`:  displays a message with green background.
+ *
+ * TODO: Use global variable for `z-index`.
+ */
+
+:root {
+    --SystemMessage--danger-background: var(--color-red-accent);
+    --SystemMessage--danger-border: var(--color-red-base);
+    --SystemMessage--positive-background: var(--color-green-accent);
+    --SystemMessage--positive-border: var(--color-green-base);
+    --SystemMessage-background: var(--color-blue-accent);
+    --SystemMessage-border: var(--color-blue-base);
+    --SystemMessage-border-width: 1px;
+    --SystemMessage-gutter-width: 2em;
+    --SystemMessage-image-width: 4px;
+}
+
+/**
+ * 1. Calculate position to include half width of background image.
+ */
+
+.SystemMessage {
+    background-color: var(--SystemMessage-border);
+    background-image: url("images/SystemMessage-background.svg");
+    background-position: calc((var(--SystemMessage-gutter-width) / 2) - (var(--SystemMessage-image-width) / 2)) center; /* 1 */
+    background-repeat: no-repeat;
+    border-color: var(--SystemMessage-border);
+    border-radius: 3px;
+    border-style: solid;
+    border-width: var(--SystemMessage-border-width);
+    box-shadow: var(--effect-box-shadow);
+    margin: 2em 0;
+    max-width: 46.25em;
+    padding-left: calc(var(--SystemMessage-gutter-width) - var(--SystemMessage-border-width));
+}
+
+.SystemMessage-inner {
+    background-color: var(--SystemMessage-background);
+    padding: 1em 1.5em;
+}
+
+.SystemMessage-body {
+    margin-bottom: 1em;
+}
+
+.SystemMessage-details {
+    margin-bottom: 1em;
+}
+
+.SystemMessage-action {
+    margin-bottom: 0.5em;
+    text-align: right;
+}
+
+/**
+ * Danger modifier
+ */
+
+.SystemMessage--danger {
+    background-color: var(--SystemMessage--danger-border);
+    border-color: var(--SystemMessage--danger-border);
+}
+
+.SystemMessage--danger .SystemMessage-inner {
+    background-color: var(--SystemMessage--danger-background);
+}
+
+/**
+ * Positive modifier
+ */
+
+.SystemMessage--positive {
+    background-color: var(--SystemMessage--positive-border);
+    border-color: var(--SystemMessage--positive-border);
+}
+
+.SystemMessage--positive .SystemMessage-inner {
+    background: var(--SystemMessage--positive-background);
+}

--- a/test/unit/rb-system-message/rb-system-message.spec.js
+++ b/test/unit/rb-system-message/rb-system-message.spec.js
@@ -1,0 +1,26 @@
+define([
+    'components/rb-system-message',
+    'html!./rb-system-message.tpl.html'
+], function (rbSystemMessage, template) {
+    describe('rb-system-message', function () {
+
+        var $scope,
+            $compile,
+            textControl,
+            element;
+
+        beforeEach(angular.mock.module('rb-system-message'));
+
+        beforeEach(inject(function (_$compile_, _$rootScope_) {
+            $scope = _$rootScope_.$new({});
+            $compile = _$compile_;
+            rbSystemMessage = angular.element(template);
+            element = $compile(rbSystemMessage)($scope);
+            $scope.$apply();
+        }));
+
+        it('should do something', function () {
+        });
+
+    });
+});

--- a/test/unit/rb-system-message/rb-system-message.tpl.html
+++ b/test/unit/rb-system-message/rb-system-message.tpl.html
@@ -1,0 +1,1 @@
+<rb-system-message></rb-system-message>


### PR DESCRIPTION
TP: https://rockabox.tpondemand.com/entity/8748

This component only displays the messages; it doesn't position them in the viewport.

Inline show/hide (for "Technical Details" => textarea) dropped to backlog: https://rockabox.tpondemand.com/entity/8893

`rb-text-control` needs something like an "output" extension to:

* Set value attribute or contents of `textarea`, depending on element type
* Disable `textarea` enlarge (either as utility class or attached to modifier)
* No validation (disable focus states)
* Set `readonly` attribute (can still copy out, but can't modify)
