### PR TITLE
Allow use of ui-sref in nav component.

### DIFF
--- a/src/rb-nav-bar/rb-nav-bar.tpl.html
+++ b/src/rb-nav-bar/rb-nav-bar.tpl.html
@@ -1,8 +1,10 @@
 <nav class="Navigation" role="navigation">
     <ul class="Navigation-items">
-        <li class="Navigation-item" ng-repeat="option in ::options track by $index">
-            <a class="Navigation-itemInner" ng-class="{ 'is-active': isactivefunction({id:option.id})}"
-                ng-click="clickfunction({id:option.id})" ng-aria>
+        <li class="Navigation-item" ng-repeat="option in ::options track by $index" ng-switch="!option.state">
+            <a ng-switch-when="true" ng-attr-href="{{ option.url }}" class="Navigation-itemInner" ng-class="{ 'is-active': isactivefunction({id:option.id})}" ng-click="clickfunction({id:option.id})" ng-aria>
+                {{::option.text}}
+            </a>
+            <a ng-switch-when="false" ui-sref="{{ option.state }}" ui-sref-active="is-active" class="Navigation-itemInner"  ng-aria>
                 {{::option.text}}
             </a>
         </li>

--- a/src/rb-page-header/demo/demo-ctrl.js
+++ b/src/rb-page-header/demo/demo-ctrl.js
@@ -25,9 +25,9 @@ define([
         };
 
         this.options = [
-            {'id': 1, 'text': 'Campaigns'},
-            {'id': 2, 'text': 'Reporting'},
-            {'id': 3, 'text': 'Creatives'}
+            {'id': 1, 'text': 'Campaigns', 'state': 'rb-badge'},
+            {'id': 2, 'text': 'Reporting', 'url': 'http://google.com'},
+            {'id': 3, 'text': 'Creatives', 'state': false}
         ];
 
     }

--- a/test/unit/rb-nav-bar/rb-nav-bar.spec.js
+++ b/test/unit/rb-nav-bar/rb-nav-bar.spec.js
@@ -7,8 +7,8 @@ define([
             $compile,
             _options = [
                 {'id': '31', 'text': 'Option 1'},
-                {'id': '37', 'text': 'Option 2'},
-                {'id': '41', 'text': 'Option 3'}
+                {'id': '37', 'text': 'Option 2', 'state': 'test-state'},
+                {'id': '41', 'text': 'Option 3', 'url': 'http://example.com'}
             ],
             _clickfunction = function (id) {
                 return id;
@@ -64,6 +64,26 @@ define([
                 $scope.$apply();
                 options = angular.element(element.find('a'));
                 expect(options[0].outerHTML).toContain('ng-click="clickfunction(');
+            });
+
+            it('should set ui-sref if option has a state', function () {
+                var navBar = angular.element(template),
+                    element = $compile(navBar)($scope),
+                    options;
+
+                $scope.$apply();
+                options = angular.element(element.find('a'));
+                expect(angular.element(options[1]).attr('ui-sref')).toBe('test-state');
+            });
+
+            it('should set ui-sref if option has a state', function () {
+                var navBar = angular.element(template),
+                    element = $compile(navBar)($scope),
+                    options;
+
+                $scope.$apply();
+                options = angular.element(element.find('a'));
+                expect(angular.element(options[2]).attr('href')).toBe('http://example.com');
             });
 
             it('should attach an isactivefunction to the navigation options', function () {


### PR DESCRIPTION
As we noticed in @nwhite89 's PR: https://github.com/rockabox/rbx_campaign_management/pull/38

We can't use `ui-sref` in nav links. This PR adds the ability to use `ui-sref` or `href` in the states without having to use an `onClickFunction`.

I've kept the existing methods in there for flexibility.

