### PR TITLE
Ensure components that are dependent on others require them

### DIFF
--- a/src/rb-page-title/index.js
+++ b/src/rb-page-title/index.js
@@ -1,7 +1,8 @@
 define([
     './rb-page-title-directive',
+    'components/rb-badge',
     './rb-page-title.css'
-], function (rbPageTitleDirective, css) {
+], function (rbPageTitleDirective, rbBadge, css) {
     /**
      * @ngdoc module
      * @name rb-page-title
@@ -11,7 +12,9 @@ define([
      *
      */
     var rbHeader = angular
-        .module('rb-page-title', [])
+        .module('rb-page-title', [
+            rbBadge.name
+        ])
         .directive('rbPageTitle', rbPageTitleDirective);
 
     return rbHeader;

--- a/src/rb-warning-messages/index.js
+++ b/src/rb-warning-messages/index.js
@@ -1,7 +1,8 @@
 define([
     './rb-warning-messages-directive',
+    'components/rb-icon',
     './rb-warning-messages.css'
-], function (rbWarningMessagesDirective) {
+], function (rbWarningMessagesDirective, rbIcon, css) {
     /**
      * @ngdoc module
      * @name rb-warning-messages
@@ -11,7 +12,9 @@ define([
      *
      */
     var rbWarningMessages = angular
-        .module('rb-warning-messages', [])
+        .module('rb-warning-messages', [
+            rbIcon.name
+        ])
         .directive('rbWarningMessages', rbWarningMessagesDirective);
 
     return rbWarningMessages;

--- a/test/unit/rb-page-title/rb-page-title.spec.js
+++ b/test/unit/rb-page-title/rb-page-title.spec.js
@@ -33,19 +33,35 @@ define([
             expect(element.html()).toContain('My Subheading');
         });
 
-        it('should attach a badge to the page title', function () {
-            var badgeEle;
+        describe('badge', function () {
+            it('should attach a badge to the page title', function () {
+                var pageTitleBadgeWrapper,
+                    badgeEle;
 
-            pageTitle.attr('badge-status', 'statusFinished');
+                pageTitle.attr('badge-status', 'statusFinished');
 
-            element = $compile(pageTitle)($scope);
+                element = $compile(pageTitle)($scope);
 
-            $scope.$apply();
+                $scope.$apply();
 
-            badgeEle = element.find('rb-badge');
+                pageTitleBadgeWrapper = element[0].getElementsByClassName('PageTitle-badge');
+                badgeEle = angular.element(pageTitleBadgeWrapper).find('div')[0];
 
-            expect(badgeEle.length).toBe(1);
-            expect(angular.element(badgeEle[0]).attr('state')).toBe('statusFinished');
+                expect(pageTitleBadgeWrapper.length).toBe(1);
+                expect(angular.element(badgeEle).attr('state')).toBe('statusFinished');
+            });
+
+            it('should not attach a badge to the page title', function () {
+                var pageTitleBadgeWrapper;
+
+                element = $compile(pageTitle)($scope);
+
+                $scope.$apply();
+
+                pageTitleBadgeWrapper = element[0].getElementsByClassName('PageTitle-badge');
+
+                expect(pageTitleBadgeWrapper.length).toBe(0);
+            });
         });
 
         describe('back to parent', function () {


### PR DESCRIPTION
When a component needs to use another rb-component explicitly to render, ensure that the componenent requires via Webpack and via the Angular module dependency injection.