### PR TITLE
Fix currency font size

### DIFF
--- a/src/rb-currency/rb-currency.css
+++ b/src/rb-currency/rb-currency.css
@@ -6,25 +6,19 @@
  */
 
 :root {
-    --Currency-cent-font-size: var(--font-size-x-small);
-    --Currency-unit-font-size: var(--font-size);
+    --Currency-cent-font-size: 0.75em;
+    --Currency-unit-font-size: inherit;
 }
 
 /**
- * 1. Regrettable fix to remove whitespace between inline components.
- *    See: http://davidwalsh.name/remove-whitespace-inline-block
- * 2. Reset unit size to default.
- * 3. Reduce cent font size.
+ * 1. Inherit context font-size.
+ * 2. Proportionally reduce cent font size.
  */
 
-.Currency {
-    font-size: 0; /* 1 */
-}
-
 .Currency-unit {
-    font-size: var(--Currency-unit-font-size); /* 2 */
+    font-size: var(--Currency-unit-font-size); /* 1 */
 }
 
 .Currency-cent {
-    font-size: var(--Currency-cent-font-size); /* 3 */
+    font-size: var(--Currency-cent-font-size); /* 2 */
 }


### PR DESCRIPTION
* Stop hardcoding; inherit for main part and do proportional resize on cent.
* Remove regrettable hack to remove spacing when tags not inline; directive in place so no longer necessary.