### PR TITLE
Creates-a-Progress-Button-attr-directive

### DIFF
--- a/dev/app.js
+++ b/dev/app.js
@@ -22,6 +22,7 @@ define([
     'components/rb-system-message/demo',
     'components/rb-text-control/demo',
     'components/rb-warning-messages/demo',
+    'components/rb-progress-button/demo',
     'rbx_style_guide'
 ], function (
     uiRouter,
@@ -47,6 +48,7 @@ define([
     rbSystemMessage,
     rbTextControlDemo,
     rbWarningMessagesDemo,
+    rbProgressButtonDemo,
     css
 ) {
     // @ngInject
@@ -73,8 +75,8 @@ define([
             rbSiteDemo.name,
             rbSystemMessage.name,
             rbTextControlDemo.name,
-            rbWarningMessagesDemo.name
-
+            rbWarningMessagesDemo.name,
+            rbProgressButtonDemo.name
         ])
         .config(function ($stateProvider, $httpProvider) {
 

--- a/src/rb-progress-button/demo/demo-ctrl.js
+++ b/src/rb-progress-button/demo/demo-ctrl.js
@@ -1,0 +1,105 @@
+define([
+], function () {
+
+    // @ngInject
+    function demoCtrl ($rootScope, $state, $injector, $q, $timeout) {
+
+        this.itemList = [
+            {
+                'id': 1,
+                'status': 'Pending',
+                'name': 'Item #1',
+                'description': 'Description #1'
+            },
+            {
+                'id': 2,
+                'status': 'Live',
+                'name': 'Item #2',
+                'description': 'Description #2'
+            },
+            {
+                'id': 3,
+                'status': 'Paused',
+                'name': 'Item #3',
+                'description': 'Description #3'
+            },
+            {
+                'id': 4,
+                'status': 'Pending',
+                'name': 'Item #4',
+                'description': 'Fails to publish'
+            }
+        ];
+
+        this.start = function (item) {
+
+            var promise = publish(item);
+
+            promise.then(function (result) {
+                console.log('Success: ' + result);
+                item.status = 'Live';
+            }, function (reason) {
+                console.log('Failure: ' + reason);
+            });
+
+            return promise;
+        };
+
+        this.pause = function (item) {
+
+            var promise = pause(item);
+
+            promise.then(function (result) {
+                console.log('Success: ' + result);
+                item.status = 'Paused';
+            }, function (reason) {
+                console.log('Failure: ' + reason);
+            });
+
+            return promise;
+        };
+
+        this.republish = function (item) {
+
+            var promise = publish(item);
+
+            promise.then(function (result) {
+                console.log('Success: ' + result);
+                item.status = 'Live';
+            }, function (reason) {
+                console.log('Failure: ' + reason);
+            });
+
+            return promise;
+        };
+
+        function publish (item) {
+
+            return $q(function (resolve, reject) {
+                setTimeout(function () {
+                    if (item.id<4) {
+                        resolve('LIVE !!!');
+                    } else {
+                        reject('ERROR.');
+                    }
+                }, 10000);
+            });
+        }
+
+        function pause (item) {
+
+            return $q(function (resolve, reject) {
+                setTimeout(function () {
+                    if (item.id<4) {
+                        resolve('PAUSED !!!');
+                    } else {
+                        reject('ERROR.');
+                    }
+                }, 10000);
+            });
+        }
+
+    }
+
+    return demoCtrl;
+});

--- a/src/rb-progress-button/demo/demo-state.js
+++ b/src/rb-progress-button/demo/demo-state.js
@@ -1,0 +1,15 @@
+define([
+    'html!./demo.tpl.html'
+], function (template) {
+
+    // @ngInject
+    function demoState ($stateProvider, $urlRouterProvider) {
+        $stateProvider.state('rb-progress-button', {
+            url: '/rb-progress-button',
+            controller: 'demo-rb-progress-button-ctrl as demoCtrl',
+            template: template
+        });
+    }
+
+    return demoState;
+});

--- a/src/rb-progress-button/demo/demo.tpl.html
+++ b/src/rb-progress-button/demo/demo.tpl.html
@@ -1,64 +1,62 @@
-<div class="DataActionTable">
-    <table class="DataActionTable-main">
-        <thead>
-            <tr class="DataActionTable-row">
-                <th class="DataActionTable-cellHeader DataActionTable-colUtility DataActionTable-cellHeader--sortable u-textCenter" scope="col">
-                </th>
-                <th class="DataActionTable-cellHeader DataActionTable-cellHeader--sortable is-sortedDescending" scope="col">
-                    <a class="DataActionTable-cellHeaderItem">Status</a>
-                </th>
-                <th class="DataActionTable-cellHeader DataActionTable-cellHeader--sortable is-sortedDescending" scope="col">
-                    <a class="DataActionTable-cellHeaderItem">Row name</a>
-                </th>
-                <th class="DataActionTable-cellHeader DataActionTable-cellHeader--sortable is-sortedDescending" scope="col">
-                    <a class="DataActionTable-cellHeaderItem">Row description</a>
-                </th>
-                <th class="DataActionTable-cellHeader DataActionTable-colUtility">
-                    <span class="DataActionTable-cellHeaderItem u-hiddenVisually">
-                        Line actions
-                    </span>
-                </th>
-            </tr>
-        </thead>
-        <tbody class="DataActionTable-body">
-            <tr class="DataActionTable-row" ng-repeat="item in demoCtrl.itemList track by $index">
-                <td class="DataActionTable-cellData u-textCenter">
-                    <div class="DataActionTable-cellDataItem">
-                        <rb-badge state="status{{item.status}}" collapsed="true"></rb-badge>
-                    </div>
-                </td>
-                <th class="DataActionTable-cellData" scope="row">
-                    <div class="DataActionTable-cellDataItem">
-                        {{item.status}}
-                    </div>
-                </th>
-                <th class="DataActionTable-cellData" scope="row">
-                    <div class="DataActionTable-cellDataItem">
-                        <a href="#">{{item.name}}</a>
-                    </div>
-                </th>
-                <th class="DataActionTable-cellData" scope="row">
-                    <div class="DataActionTable-cellDataItem">
-                        <a href="#">{{item.description}}</a>
-                    </div>
-                </th>
-                <td class="DataActionTable-cellData u-textCenter">
-                    <rb-button size="small" state="positive" block="yes" ng-if="item.status==='Pending'"
-                        rb-progress-button on-execute="demoCtrl.start(item)"
-                        interval="2000"
-                        action-label="Publishing"
-                        progress-label="Please Wait">Publish</rb-button>
-                    <rb-button size="small" state="danger" outline="yes" block="yes" ng-if="item.status==='Live'"
-                        rb-progress-button on-execute="demoCtrl.pause(item)"
-                        action-label="Pausing"
-                        progress-label="Please Wait">Pause</rb-button>
-                    <rb-button size="small" state="positive" outline="yes" block="yes" ng-if="item.status==='Paused'"
-                        rb-progress-button on-execute="demoCtrl.republish(item)"
-                        interval="300"
-                        action-label="Publishing"
-                        progress-label="Please Wait">Re-Publish</rb-button>
-                </td>
-            </tr>
-        </tbody>
-    </table>
-</div>
+<table>
+    <thead>
+        <tr>
+            <th>
+            </th>
+            <th>
+                <a>Status</a>
+            </th>
+            <th>
+                <a>Row name</a>
+            </th>
+            <th>
+                <a>Row description</a>
+            </th>
+            <th>
+                <span>
+                    Line actions
+                </span>
+            </th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr ng-repeat="item in demoCtrl.itemList track by $index">
+            <td>
+                <div>
+                    <rb-badge state="status{{item.status}}" collapsed="true"></rb-badge>
+                </div>
+            </td>
+            <th>
+                <div>
+                    {{item.status}}
+                </div>
+            </th>
+            <th>
+                <div>
+                    <a href="#">{{item.name}}</a>
+                </div>
+            </th>
+            <th>
+                <div>
+                    <a href="#">{{item.description}}</a>
+                </div>
+            </th>
+            <td>
+                <rb-button size="small" state="positive" block="yes" ng-if="item.status==='Pending'"
+                    rb-progress-button on-execute="demoCtrl.start(item)"
+                    interval="2000"
+                    action-label="Publishing"
+                    progress-label="Please Wait">Publish</rb-button>
+                <rb-button size="small" state="danger" outline="yes" block="yes" ng-if="item.status==='Live'"
+                    rb-progress-button on-execute="demoCtrl.pause(item)"
+                    action-label="Pausing"
+                    progress-label="Please Wait">Pause</rb-button>
+                <rb-button size="small" state="positive" outline="yes" block="yes" ng-if="item.status==='Paused'"
+                    rb-progress-button on-execute="demoCtrl.republish(item)"
+                    interval="300"
+                    action-label="Publishing"
+                    progress-label="Please Wait">Re-Publish</rb-button>
+            </td>
+        </tr>
+    </tbody>
+</table>

--- a/src/rb-progress-button/demo/demo.tpl.html
+++ b/src/rb-progress-button/demo/demo.tpl.html
@@ -1,0 +1,64 @@
+<div class="DataActionTable">
+    <table class="DataActionTable-main">
+        <thead>
+            <tr class="DataActionTable-row">
+                <th class="DataActionTable-cellHeader DataActionTable-colUtility DataActionTable-cellHeader--sortable u-textCenter" scope="col">
+                </th>
+                <th class="DataActionTable-cellHeader DataActionTable-cellHeader--sortable is-sortedDescending" scope="col">
+                    <a class="DataActionTable-cellHeaderItem">Status</a>
+                </th>
+                <th class="DataActionTable-cellHeader DataActionTable-cellHeader--sortable is-sortedDescending" scope="col">
+                    <a class="DataActionTable-cellHeaderItem">Row name</a>
+                </th>
+                <th class="DataActionTable-cellHeader DataActionTable-cellHeader--sortable is-sortedDescending" scope="col">
+                    <a class="DataActionTable-cellHeaderItem">Row description</a>
+                </th>
+                <th class="DataActionTable-cellHeader DataActionTable-colUtility">
+                    <span class="DataActionTable-cellHeaderItem u-hiddenVisually">
+                        Line actions
+                    </span>
+                </th>
+            </tr>
+        </thead>
+        <tbody class="DataActionTable-body">
+            <tr class="DataActionTable-row" ng-repeat="item in demoCtrl.itemList track by $index">
+                <td class="DataActionTable-cellData u-textCenter">
+                    <div class="DataActionTable-cellDataItem">
+                        <rb-badge state="status{{item.status}}" collapsed="true"></rb-badge>
+                    </div>
+                </td>
+                <th class="DataActionTable-cellData" scope="row">
+                    <div class="DataActionTable-cellDataItem">
+                        {{item.status}}
+                    </div>
+                </th>
+                <th class="DataActionTable-cellData" scope="row">
+                    <div class="DataActionTable-cellDataItem">
+                        <a href="#">{{item.name}}</a>
+                    </div>
+                </th>
+                <th class="DataActionTable-cellData" scope="row">
+                    <div class="DataActionTable-cellDataItem">
+                        <a href="#">{{item.description}}</a>
+                    </div>
+                </th>
+                <td class="DataActionTable-cellData u-textCenter">
+                    <rb-button size="small" state="positive" block="yes" ng-if="item.status==='Pending'"
+                        rb-progress-button on-execute="demoCtrl.start(item)"
+                        interval="2000"
+                        action-label="Publishing"
+                        progress-label="Please Wait">Publish</rb-button>
+                    <rb-button size="small" state="danger" outline="yes" block="yes" ng-if="item.status==='Live'"
+                        rb-progress-button on-execute="demoCtrl.pause(item)"
+                        action-label="Pausing"
+                        progress-label="Please Wait">Pause</rb-button>
+                    <rb-button size="small" state="positive" outline="yes" block="yes" ng-if="item.status==='Paused'"
+                        rb-progress-button on-execute="demoCtrl.republish(item)"
+                        interval="300"
+                        action-label="Publishing"
+                        progress-label="Please Wait">Re-Publish</rb-button>
+                </td>
+            </tr>
+        </tbody>
+    </table>
+</div>

--- a/src/rb-progress-button/demo/index.js
+++ b/src/rb-progress-button/demo/index.js
@@ -1,0 +1,14 @@
+define([
+    '../index.js',
+    './demo-ctrl',
+    './demo-state'
+], function (rbProgressButton, demoCtrl, demoState) {
+    var demo = angular
+        .module('rb-progress-button-demo', [
+            rbProgressButton.name
+        ])
+        .config(demoState)
+        .controller('demo-rb-progress-button-ctrl', demoCtrl);
+
+    return demo;
+});

--- a/src/rb-progress-button/index.js
+++ b/src/rb-progress-button/index.js
@@ -1,0 +1,19 @@
+define([
+    './rb-progress-button-directive',
+    './rb-progress-button.css'
+], function (rbProgressButtonDirective, css) {
+    /**
+     * @ngdoc module
+     * @name rb-progress-button
+     * @description
+     *
+     * rbProgressButton
+     *
+     */
+    var rbProgressButton = angular
+        .module('rb-progress-button', [])
+        .directive('rbProgressButton', rbProgressButtonDirective);
+
+    return rbProgressButton;
+
+});

--- a/src/rb-progress-button/rb-progress-button-directive.js
+++ b/src/rb-progress-button/rb-progress-button-directive.js
@@ -64,9 +64,12 @@ define([
                 // Default progress message
                 progressLabel = 'Please Wait';
 
+            // Overrides the default interval attribute
+            // if an interval attribute is present
+            // with a numeric value.
             if (angular.isDefined(attr.interval) &&
-                !isNaN(parseInt(attr.interval)) &&
-                isFinite(attr.interval)) {
+                    !isNaN(parseInt(attr.interval)) &&
+                    isFinite(attr.interval)) {
 
                 interval = attr.interval;
             }
@@ -129,8 +132,8 @@ define([
                 // Execution not allowed if any execution is under way
                 // or execute function is not present
                 if (angular.isDefined(stopInterval) ||
-                    angular.isUndefined(attr.onExecute) ||
-                    angular.equals(attr.onExecute, '')) {
+                        angular.isUndefined(attr.onExecute) ||
+                        angular.equals(attr.onExecute, '')) {
 
                     return;
                 }

--- a/src/rb-progress-button/rb-progress-button-directive.js
+++ b/src/rb-progress-button/rb-progress-button-directive.js
@@ -1,0 +1,150 @@
+define([
+    'html!./rb-progress-button.tpl.html'
+], function (template) {
+
+    /**
+     * @ngdoc directive
+     * @name rbProgressButton
+     * @module rb-progress-button
+     *
+     * @restrict A
+     *
+     * @description
+     * `<rb-progress-button>` is an attribute directive that changes the default
+     * behaviour of a `<button>` from a single click to a click event that
+     * triggers an execution process that changes the button text between two
+     * states (messages) every given time interval elapses.
+     *
+     * If you supply an `action-label` attribute, it will be set as the first
+     * message to replace the current button label. Defaults to `Executing`
+     *
+     * If you supply a `progress-label` attribute, it will be set as the second
+     * message to replace the button action label after a time interval elapses.
+     * Defaults to `Please Wait`
+     *
+     * If you supply an `interval` attribute with a number as a value, it will set
+     * the amount of time for the button label to change between two states (messages)
+     * Defaults to 2000 milliseconds (2 seconds)
+     *
+     * @scope
+     *  'onExecute': a custom function -that returns a promise- to be executed
+     *               when button is clicked.
+     *
+     * @usage
+     * <hljs lang="html">
+     *   <rb-button size="small" state="positive" outline="yes"
+     *       rb-progress-button on-execute="demoCtrl.publish()"
+     *       interval="500"
+     *       action-label="Publishing"
+     *       progress-label="Please Wait">Publish</rb-button>
+     * </hljs>
+     *
+     * @ngInject
+     */
+    function rbProgressButtonDirective ($interval) {
+
+        return {
+            scope: {
+                onExecute: '&'
+            },
+            restrict: 'A',
+            replace: true,
+            link: link
+        };
+
+        function link (scope, elem, attr) {
+
+            var stopInterval,
+                originalLabel,
+                currentLabel,
+                // Default interval of 2000 milliseconds
+                interval = 2000,
+                // Default action message
+                actionLabel = 'Executing',
+                // Default progress message
+                progressLabel = 'Please Wait';
+
+            if (angular.isDefined(attr.interval) &&
+                !isNaN(parseInt(attr.interval)) &&
+                isFinite(attr.interval)) {
+
+                interval = attr.interval;
+            }
+
+            if (angular.isDefined(attr.actionLabel) && !angular.equals(attr.actionLabel, '')) {
+                actionLabel = attr.actionLabel;
+            }
+
+            if (angular.isDefined(attr.progressLabel) && !angular.equals(attr.progressLabel, '')) {
+                progressLabel = attr.progressLabel;
+            }
+
+            function onClick () {
+
+                originalLabel = elem.text();
+                currentLabel = actionLabel;
+
+                if (!(angular.isDefined(attr.outline) && angular.equals(attr.outline, 'yes'))) {
+                    elem.addClass('Button--outline');
+                    elem.removeClass('Button--standard');
+                }
+
+                elem.text(currentLabel);
+                elem[0].blur();
+
+                stopInterval = $interval(function () {
+                    if (currentLabel === progressLabel) {
+                        currentLabel = actionLabel;
+                    } else {
+                        currentLabel = progressLabel;
+                    }
+                    elem.text(currentLabel);
+                }, interval);
+
+                startExecution();
+            }
+
+            function startExecution () {
+
+                scope.onExecute().then(function (result) {
+                    tearDown();
+                }, function (error) {
+                    tearDown();
+                });
+            }
+
+            function tearDown () {
+
+                $interval.cancel(stopInterval);
+                stopInterval = undefined;
+                if (!(angular.isDefined(attr.outline) && angular.equals(attr.outline, 'yes'))) {
+                    elem.addClass('Button--standard');
+                    elem.removeClass('Button--outline');
+                }
+                elem.text(originalLabel);
+            }
+
+            elem.on('click', function (event) {
+
+                // Execution not allowed if any execution is under way
+                // or execute function is not present
+                if (angular.isDefined(stopInterval) ||
+                    angular.isUndefined(attr.onExecute) ||
+                    angular.equals(attr.onExecute, '')) {
+
+                    return;
+                }
+
+                onClick();
+            });
+
+            elem.on('$destroy', function () {
+                $interval.cancel(stopInterval);
+                stopInterval = undefined;
+            });
+
+        }
+    }
+
+    return rbProgressButtonDirective;
+});

--- a/src/rb-progress-button/rb-progress-button.css
+++ b/src/rb-progress-button/rb-progress-button.css
@@ -1,0 +1,16 @@
+/** @define rbProgressButton; use strict */
+
+/**
+ * The `.rbProgressButton` component...
+ */
+
+:root {
+    --rbProgressButton-variable: var();
+}
+
+/**
+ * 1. Comment
+ */
+
+.rbProgressButton {
+}

--- a/test/unit/rb-progress-button/rb-progress-button-no-function.tpl.html
+++ b/test/unit/rb-progress-button/rb-progress-button-no-function.tpl.html
@@ -1,2 +1,2 @@
-<button rb-progress-button interval="2000" action-label="Publishing"
-    progress-label="Please Wait">Publish</button>
+<rb-button rb-progress-button interval="2000" action-label="Publishing"
+    progress-label="Please Wait">Publish</rb-button>

--- a/test/unit/rb-progress-button/rb-progress-button-no-function.tpl.html
+++ b/test/unit/rb-progress-button/rb-progress-button-no-function.tpl.html
@@ -1,0 +1,2 @@
+<button rb-progress-button interval="2000" action-label="Publishing"
+    progress-label="Please Wait">Publish</button>

--- a/test/unit/rb-progress-button/rb-progress-button.spec.js
+++ b/test/unit/rb-progress-button/rb-progress-button.spec.js
@@ -1,0 +1,171 @@
+define([
+    'components/rb-progress-button',
+    'html!./rb-progress-button.tpl.html',
+    'html!./rb-progress-button-no-function.tpl.html'
+], function (rbProgressButton, template, templateNoFunction) {
+    describe('rb-progress-button', function () {
+
+        var $scope,
+            $compile,
+            $timeout,
+            $interval,
+            $q,
+            deferredResolution,
+            element,
+            isolatedScope;
+
+        beforeEach(angular.mock.module('rb-progress-button'));
+
+        beforeEach(inject(function (_$compile_, _$rootScope_, _$timeout_, _$interval_, _$q_) {
+            $scope = _$rootScope_.$new({});
+            $compile = _$compile_;
+            $timeout = _$timeout_;
+            $interval = _$interval_;
+            $q = _$q_;
+            deferredResolution = $q.defer();
+            rbProgressButton = angular.element(template);
+            element = $compile(rbProgressButton)($scope);
+            $scope.$apply();
+            isolatedScope = element.isolateScope();
+            isolatedScope.onExecute = function () {
+                return $q(function (resolve, reject) {
+                    setTimeout(function () {
+                        angular.noop();
+                    }, 2500);
+                });
+            };
+            isolatedScope.$apply();
+            spyOn(isolatedScope, 'onExecute').andReturn(deferredResolution.promise);
+        }));
+
+        describe('attribute generation', function () {
+
+            it('should convert attributes on a rb-progress-button to attributes on the generated button',
+                function () {
+                    var button = $compile('<rb-button rb-progress-button anyattr any-attr></rb-button>')($scope);
+
+                    expect(button[0].hasAttribute('anyattr')).toBe(true);
+                    expect(button[0].hasAttribute('any-attr')).toBe(true);
+                });
+        });
+
+        describe('rendering', function () {
+
+            it('should have a function bound to the onExecute property', function () {
+
+                expect(element[0].hasAttribute('on-execute')).toBe(true);
+                expect(element.attr('on-execute')).toEqual('executeFunction()');
+            });
+
+            it('should have a time interval value if interval attribute is present', function () {
+
+                expect(element[0].hasAttribute('interval')).toBe(true);
+                expect(element.attr('interval')).toEqual('2000');
+            });
+
+            it('should have an action label value if actionLabel attribute is present', function () {
+
+                expect(element[0].hasAttribute('action-label')).toBe(true);
+                expect(element.attr('action-label')).toEqual('Publishing');
+            });
+
+            it('should have a progress label value if progressLabel attribute is present', function () {
+
+                expect(element[0].hasAttribute('progress-label')).toBe(true);
+                expect(element.attr('progress-label')).toEqual('Please Wait');
+            });
+
+        });
+
+        describe('link function', function () {
+
+            it('should not change button text on a click if onExecute attribute is not present', function () {
+
+                rbProgressButton = angular.element(templateNoFunction);
+                element = $compile(rbProgressButton)($scope);
+
+                expect(element.text()).toBe('Publish');
+                element.triggerHandler('click');
+                $interval.flush(100);
+                expect(element.text()).toBe('Publish');
+            });
+
+            it('should change button text (every 2 seconds) when clicked and onExecute attr present', function () {
+
+                expect(element.text()).toBe('Publish');
+                element.triggerHandler('click');
+                $interval.flush(1);
+                expect(element.text()).toBe('Publishing');
+                $interval.flush(1999);
+                expect(element.text()).toBe('Please Wait');
+            });
+
+            it('should not add the class `Button--outline` when clicked and onExecute attr present', function () {
+
+                rbProgressButton = angular.element(templateNoFunction);
+                element = $compile(rbProgressButton)($scope);
+
+                expect(rbProgressButton.hasClass('Button--outline')).toBe(false);
+                element.triggerHandler('click');
+                $interval.flush(1);
+                expect(rbProgressButton.hasClass('Button--outline')).toBe(false);
+            });
+
+            it('should add the class `Button--outline` when clicked and onExecute attr present', function () {
+
+                expect(rbProgressButton.hasClass('Button--outline')).toBe(false);
+                element.triggerHandler('click');
+                $interval.flush(1);
+                expect(rbProgressButton.hasClass('Button--outline')).toBe(true);
+            });
+
+            it('should not call `onExecute` function when clicked and onExecute attr not present', function () {
+
+                rbProgressButton = angular.element(templateNoFunction);
+                element = $compile(rbProgressButton)($scope);
+
+                element.triggerHandler('click');
+                deferredResolution.resolve();
+                isolatedScope.$digest();
+
+                expect(isolatedScope.onExecute).not.toHaveBeenCalled();
+            });
+
+            it('should call the `onExecute` function when button is clicked and onExecute attr present', function () {
+
+                element.triggerHandler('click');
+                deferredResolution.resolve();
+                isolatedScope.$digest();
+
+                expect(isolatedScope.onExecute).toHaveBeenCalled();
+            });
+
+            it('should show the original button label when execution finishes', function () {
+
+                element.triggerHandler('click');
+                $interval.flush(1);
+                expect(element.text()).toBe('Publishing');
+                $interval.flush(1999);
+                expect(element.text()).toBe('Please Wait');
+
+                deferredResolution.resolve();
+                isolatedScope.$digest();
+
+                expect(element.text()).toBe('Publish');
+            });
+
+            it('should have the class `Button--standard` when execution finishes', function () {
+
+                element.triggerHandler('click');
+                $interval.flush(1);
+                expect(rbProgressButton.hasClass('Button--standard')).toBe(false);
+
+                deferredResolution.resolve();
+                isolatedScope.$digest();
+
+                expect(rbProgressButton.hasClass('Button--standard')).toBe(true);
+            });
+
+        });
+    });
+});

--- a/test/unit/rb-progress-button/rb-progress-button.tpl.html
+++ b/test/unit/rb-progress-button/rb-progress-button.tpl.html
@@ -1,4 +1,4 @@
-<button rb-progress-button on-execute="executeFunction()"
+<rb-button rb-progress-button on-execute="executeFunction()"
     interval="2000"
     action-label="Publishing"
-    progress-label="Please Wait">Publish</button>
+    progress-label="Please Wait">Publish</rb-button>

--- a/test/unit/rb-progress-button/rb-progress-button.tpl.html
+++ b/test/unit/rb-progress-button/rb-progress-button.tpl.html
@@ -1,0 +1,4 @@
+<button rb-progress-button on-execute="executeFunction()"
+    interval="2000"
+    action-label="Publishing"
+    progress-label="Please Wait">Publish</button>


### PR DESCRIPTION
Creates a progress button attribute directive that changes the default behaviour of a `<button>` from a single click to a click event that triggers an execution process that changes the button label between two
states (messages) every given time interval elapses.

Includes a extended demo to show how it could be used.