### PR TITLE
Remove rogue `.u-1of2` in Grid demo

### DIFF
--- a/src/rb-grid/demo/demo.tpl.html
+++ b/src/rb-grid/demo/demo.tpl.html
@@ -29,7 +29,7 @@
                     </div>
                 </div>
             </div>
-            <div class="Grid-cell u-1of2">
+            <div class="Grid-cell">
                 <rb-data-summary type="timings">
                     <rb-data-summary-item header="Campaign Start">
                         <div class="u-textLight u-textXLarge">


### PR DESCRIPTION
We're not using any Grid-specific utilities yet.