### PR TITLE
Fix `rb-currency` spacing

### DIFF
--- a/src/rb-currency/rb-currency.tpl.html
+++ b/src/rb-currency/rb-currency.tpl.html
@@ -1,4 +1,3 @@
 <data class="Currency" value="${{ fullAmount }}">
-    <span class="Currency-unit">{{ integerPart | currency:"$":0 }}</span>
-    <span class="Currency-cent" ng-if="fractionalPart !== 0">.{{ fractionalPart }}</span>
+    <span class="Currency-unit">{{ integerPart | currency:"$":0 }}</span><span class="Currency-cent" ng-if="fractionalPart !== 0">.{{ fractionalPart }}</span>
 </data>


### PR DESCRIPTION
Inline elements should be on one line, otherwise browsers add a space in place of the line break.