### PR TITLE
Add Autoprefixer `browserslist` config for PostCSS

### DIFF
--- a/browserslist
+++ b/browserslist
@@ -1,0 +1,4 @@
+last 2 versions
+IE >= 10
+Safari >= 7.1
+iOS >= 7.1


### PR DESCRIPTION
Same version as in rockabox/rbx_style_guide.

See: https://github.com/ai/browserslist