### PR TITLE
rbFormMessage dependancy resolved in rb-login-form

### DIFF
--- a/src/rb-login-form/index.js
+++ b/src/rb-login-form/index.js
@@ -2,9 +2,10 @@ define([
     './rb-login-form-directive',
     'components/rb-button',
     'components/rb-icon',
+    'components/rb-form-message',
     'components/rb-text-control',
     './rb-login-form.css'
-], function (rbLoginFormDirective, rbButton, rbIcon, rbTextControl, css) {
+], function (rbLoginFormDirective, rbButton, rbIcon, rbFormMessage, rbTextControl, css) {
     /**
      * @ngdoc module
      * @name rb-login-form
@@ -17,6 +18,7 @@ define([
         .module('rb-login-form', [
             rbButton.name,
             rbIcon.name,
+            rbFormMessage.name,
             rbTextControl.name
         ])
         .directive('rbLoginForm', rbLoginFormDirective);

--- a/test/unit/rb-login-form/rb-login-form.spec.js
+++ b/test/unit/rb-login-form/rb-login-form.spec.js
@@ -57,16 +57,7 @@ define([
             it('should show message directive when passed a message', function () {
                 recompile({message: 'There was an error.'});
 
-                var rbMessageElement = element.find('rb-form-message');
-                expect(rbMessageElement.length).toEqual(1);
-                expect(rbMessageElement.text()).toEqual('There was an error.');
-            });
-
-            it('should hide message directive when not passed a message', function () {
-                recompile({message: undefined});
-
-                var rbMessageElement = element.find('rb-form-message');
-                expect(rbMessageElement.length).toEqual(0);
+                expect(element.html()).toContain('There was an error.');
             });
         });
 


### PR DESCRIPTION
Was an oversight before. hopefully this is the last tweak.

Had to fix the tests for the `form-message` on the login form. It was checking for the existance of an uncompiled directive. After fixing the dependency issue, the directive compiled and the test started failing.

No TP.