### PR TITLE
Wrap modal confirm in overlay.

### DIFF
--- a/src/rb-modal-confirm/rb-modal-confirm.tpl.html
+++ b/src/rb-modal-confirm/rb-modal-confirm.tpl.html
@@ -1,20 +1,24 @@
-<div class="ModalConfirm">
-    <div class="ModalConfirm-title">
-        <h2 class="u-textHeading2">{{ ::title }}</h2>
-    </div>
-    <div class="ModalConfirm-body">
-        <div class="ModalConfirm-message" ng-transclude></div>
-        <div class="ModalConfirm-action">
-            <div class="ModalConfirm-actionItem">
-                <rb-button outline="yes" ng-click="onCancel()">
-                    Cancel
-                </rb-button>
+<div>
+    <rb-overlay-modal>
+        <div class="ModalConfirm">
+            <div class="ModalConfirm-title">
+                <h2 class="u-textHeading2">{{ ::title }}</h2>
             </div>
-            <div class="ModalConfirm-actionItem">
-                <rb-button ng-click="onConfirm()">
-                    Confirm
-                </rb-button>
+            <div class="ModalConfirm-body">
+                <div class="ModalConfirm-message" ng-transclude></div>
+                <div class="ModalConfirm-action">
+                    <div class="ModalConfirm-actionItem">
+                        <rb-button outline="yes" ng-click="onCancel()">
+                            Cancel
+                        </rb-button>
+                    </div>
+                    <div class="ModalConfirm-actionItem">
+                        <rb-button ng-click="onConfirm()">
+                            Confirm
+                        </rb-button>
+                    </div>
+                </div>
             </div>
         </div>
-    </div>
+    </rb-overlay-modal>
 </div>

--- a/test/unit/rb-modal-confirm/rb-modal-confirm.spec.js
+++ b/test/unit/rb-modal-confirm/rb-modal-confirm.spec.js
@@ -8,6 +8,7 @@ define([
             isolatedScope,
             $compile,
             element,
+            overlay,
             compileTemplate;
 
         beforeEach(angular.mock.module(modalConfirm.name));
@@ -22,10 +23,21 @@ define([
                 element = $compile(template)($scope);
                 $scope.$apply();
                 isolatedScope = element.isolateScope();
+
+                overlay = element.find('rb-overlay-modal');
+                // Set element to root with 'ModalConfirm' class
+                element = angular.element(element.find('rb-overlay-modal').children()[0]);
             };
         }));
 
         describe('rendering', function () {
+
+            it('should render overlay component', function () {
+                compileTemplate('<rb-modal-confirm></rb-modal-confirm>');
+
+                expect(overlay.length).toBe(1);
+            });
+
             it('should render root, title and body with classes', function () {
                 compileTemplate('<rb-modal-confirm></rb-modal-confirm>');
 


### PR DESCRIPTION
The modal confirm **always** appears inside a modal overlay. With that in mind it seemed to make sense to have `rb-overlay-modal` inside the modal confirm template.

You'll notice a `div` added at the root of the Modal confirm template. This is because we can't have another directive as the root element of this directive.