### PR TITLE
Removed unused tpl file in unit test

### DIFF
--- a/test/unit/rb-modal-confirm/rb-modal-confirm.tpl.html
+++ b/test/unit/rb-modal-confirm/rb-modal-confirm.tpl.html
@@ -1,1 +1,0 @@
-<rb-modal-confirm></rb-modal-confirm>


### PR DESCRIPTION
Noticed a file that isn't used that I may have left in the modal-confirm tests. 

