### PR TITLE
Allow for setting target

### DIFF
--- a/src/rb-nav-bar/rb-nav-bar.tpl.html
+++ b/src/rb-nav-bar/rb-nav-bar.tpl.html
@@ -1,7 +1,14 @@
 <nav class="Navigation" role="navigation">
     <ul class="Navigation-items">
         <li class="Navigation-item" ng-repeat="option in ::options track by $index" ng-switch="!option.state">
-            <a ng-switch-when="true" ng-attr-href="{{ option.url }}" class="Navigation-itemInner" ng-class="{ 'is-active': option.active }" ng-click="clickfunction({id:option.id})" ng-aria>
+            <a
+                ng-switch-when="true"
+                ng-attr-href="{{ option.url }}"
+                class="Navigation-itemInner"
+                ng-class="{ 'is-active': option.active }"
+                ng-click="clickfunction({id:option.id})"
+                target="{{ option.target }}"
+                ng-aria>
                 {{::option.text}}
             </a>
             <a ng-switch-when="false" ui-sref="{{ option.state }}" class="Navigation-itemInner" ng-class="{ 'is-active': option.active }" ng-aria>

--- a/test/unit/rb-nav-bar/rb-nav-bar.spec.js
+++ b/test/unit/rb-nav-bar/rb-nav-bar.spec.js
@@ -8,7 +8,7 @@ define([
             _options = [
                 {'text': 'Option 1'},
                 {'text': 'Option 2', 'state': 'test-state'},
-                {'text': 'Option 3', 'url': 'http://example.com'}
+                {'text': 'Option 3', 'url': 'http://example.com', 'target': '_self'}
             ],
             template = '<rb-nav-bar options="options"></rb-nav-bar>';
 
@@ -57,7 +57,7 @@ define([
                 expect(angular.element(options[1]).attr('ui-sref')).toBe('test-state');
             });
 
-            it('should set ui-sref if option has a state', function () {
+            it('should set href if option has a url', function () {
                 var navBar = angular.element(template),
                     element = $compile(navBar)($scope),
                     options;
@@ -65,6 +65,16 @@ define([
                 $scope.$apply();
                 options = angular.element(element.find('a'));
                 expect(angular.element(options[2]).attr('href')).toBe('http://example.com');
+            });
+
+            it('should set the target if set', function () {
+                var navBar = angular.element(template),
+                    element = $compile(navBar)($scope),
+                    options;
+
+                $scope.$apply();
+                options = angular.element(element.find('a'));
+                expect(angular.element(options[2]).attr('target')).toBe('_self');
             });
         });
     });


### PR DESCRIPTION
When setting the href of a nav bar item allow it to be possible to set the target to something like ``_self`` for when needing the ui-router to no longer listen to the change as a state.

TP: https://rockabox.tpondemand.com/entity/9073