### PR TITLE
Moved angular strap to dependancies out of dev dependancies.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -21,19 +21,19 @@
   "devDependencies": {
     "angularjs": "~1.3.15",
     "angular-animate": "~1.3.0",
-    "angular-aria": "~1.3.0",
     "angular-highlightjs": "~0.3.3",
     "angular-messages": "~1.3.0",
     "angular-touch": "~1.3.0",
     "angular-mocks": "~1.3.0",
     "angular-ui-router": "~0.2.13",
-    "angular-strap": "~2.2.1",
     "rbx_style_guide": "rockabox/rbx_style_guide#develop"
   },
   "resolutions": {
     "angular": "~1.3.15"
   },
   "dependencies": {
-    "angular-elastic": "rockabox/angular-elastic#master"
+    "angular-aria": "~1.3.0",
+    "angular-elastic": "rockabox/angular-elastic#master",
+    "angular-strap": "~2.2.1"
   }
 }


### PR DESCRIPTION
Moved dependancies from `devDependancies' as they weren't being installed by other repos including this via bower.