### PR TITLE
swap ng-if for ng-show to fix broken preselected select

### DIFF
--- a/src/rb-select/rb-select.tpl.html
+++ b/src/rb-select/rb-select.tpl.html
@@ -10,7 +10,7 @@
         ng-model="selected"
         ng-disabled="{{ isDisabled }}"
         ng-required="{{ isRequired }}">
-            <option value="" ng-if="placeholder">{{ placeholder }}</option>
+            <option value="" ng-show="placeholder">{{ placeholder }}</option>
     </select>
 
     <div class="TextControl-message" ng-show="helpMessage">

--- a/test/unit/rb-select/rb-select.spec.js
+++ b/test/unit/rb-select/rb-select.spec.js
@@ -61,9 +61,9 @@ define([
             compileTemplate('<rb-select items="items" value="id" display="name"></rb-select>');
 
             optionEle = element.find('option');
-            firstOption = angular.element(optionEle[0]);
+            firstOption = angular.element(optionEle[1]);
 
-            expect(optionEle.length).toBe(4);
+            expect(optionEle.length).toBe(5);
             expect(firstOption.html()).toBe('Volvo');
         });
 


### PR DESCRIPTION
select with placeholder was broken. It was caused by the ordering of angular attributes in the template causing the placeholder to render after the select options and override the selected value (but not the model)