### PR TITLE
Custom button labels in modal confirm

### DIFF
--- a/src/rb-modal-confirm/demo/demo.tpl.html
+++ b/src/rb-modal-confirm/demo/demo.tpl.html
@@ -1,7 +1,17 @@
 <div class="ComponentView">
+
+    <h2>ModalConfirm with default button labels</h2>
     <rb-modal-confirm title="Are you sure?" on-confirm="demoCtrl.confirm()" on-cancel="demoCtrl.cancel()">
         <p>
             You are about to ACTION this ITEM.
         </p>
+    </rb-modal-confirm>
+
+    <h2>ModalConfirm with custom button labels</h2>
+    <rb-modal-confirm title="Are you sure?" on-confirm="demoCtrl.confirm()" on-cancel="demoCtrl.cancel()"
+        confirm-label="Hell yeah!!" cancel-label="Get me outta here!">
+            <p>
+                You are about to ACTION this ITEM.
+            </p>
     </rb-modal-confirm>
 </div>

--- a/src/rb-modal-confirm/index.js
+++ b/src/rb-modal-confirm/index.js
@@ -1,8 +1,9 @@
 define([
+    'components/rb-button',
     'components/rb-overlay-modal',
     './rb-modal-confirm-directive',
     './rb-modal-confirm.css'
-], function (rbOverlayModal, rbModalConfirmDirective, css) {
+], function (rbButton, rbOverlayModal, rbModalConfirmDirective, css) {
     /**
      * @ngdoc module
      * @name rb-modal-confirm
@@ -12,7 +13,10 @@ define([
      *
      */
     var rbModalConfirm = angular
-        .module('rb-modal-confirm', [rbOverlayModal.name])
+        .module('rb-modal-confirm', [
+            rbButton.name,
+            rbOverlayModal.name
+        ])
         .directive('rbModalConfirm', rbModalConfirmDirective);
 
     return rbModalConfirm;

--- a/src/rb-modal-confirm/rb-modal-confirm-directive.js
+++ b/src/rb-modal-confirm/rb-modal-confirm-directive.js
@@ -25,7 +25,9 @@ define([
             scope: {
                 title: '@',
                 onConfirm: '&',
-                onCancel: '&'
+                onCancel: '&',
+                cancelLabel: '@',
+                confirmLabel: '@'
             },
             restrict: 'E',
             replace: true,

--- a/src/rb-modal-confirm/rb-modal-confirm.tpl.html
+++ b/src/rb-modal-confirm/rb-modal-confirm.tpl.html
@@ -9,12 +9,12 @@
                 <div class="ModalConfirm-action">
                     <div class="ModalConfirm-actionItem">
                         <rb-button outline="yes" ng-click="onCancel()">
-                            Cancel
+                            {{ ::cancelLabel || "Cancel" }}
                         </rb-button>
                     </div>
                     <div class="ModalConfirm-actionItem">
                         <rb-button ng-click="onConfirm()">
-                            Confirm
+                            {{ ::confirmLabel || "Confirm" }}
                         </rb-button>
                     </div>
                 </div>

--- a/test/unit/rb-modal-confirm/rb-modal-confirm.spec.js
+++ b/test/unit/rb-modal-confirm/rb-modal-confirm.spec.js
@@ -82,19 +82,19 @@ define([
                     bodyChildren = body.children(),
                     actionsDiv = angular.element(bodyChildren[1]),
                     actions = actionsDiv.children(),
-                    fristAction = angular.element(actions[0]),
+                    firstAction = angular.element(actions[0]),
                     secondAction = angular.element(actions[1]);
 
                 expect(actions.length).toBe(2);
-                expect(fristAction.hasClass('ModalConfirm-actionItem')).toBe(true);
+                expect(firstAction.hasClass('ModalConfirm-actionItem')).toBe(true);
                 expect(secondAction.hasClass('ModalConfirm-actionItem')).toBe(true);
-                expect(fristAction.find('rb-button').length).toBe(1);
-                expect(secondAction.find('rb-button').length).toBe(1);
-                expect(angular.element(fristAction.find('rb-button')[0]).attr('outline')).toBe('yes');
-                expect(angular.element(fristAction.find('rb-button')[0]).attr('ng-click')).toBe('onCancel()');
-                expect(angular.element(fristAction.find('rb-button')[0]).text().trim()).toBe('Cancel');
-                expect(angular.element(secondAction.find('rb-button')[0]).text().trim()).toBe('Confirm');
-                expect(angular.element(secondAction.find('rb-button')[0]).attr('ng-click')).toBe('onConfirm()');
+                expect(firstAction.find('button').length).toBe(1);
+                expect(secondAction.find('button').length).toBe(1);
+                expect(angular.element(firstAction.find('button')[0]).attr('outline')).toBe('yes');
+                expect(angular.element(firstAction.find('button')[0]).attr('ng-click')).toBe('onCancel()');
+                expect(angular.element(firstAction.find('button')[0]).text().trim()).toBe('Cancel');
+                expect(angular.element(secondAction.find('button')[0]).text().trim()).toBe('Confirm');
+                expect(angular.element(secondAction.find('button')[0]).attr('ng-click')).toBe('onConfirm()');
             });
         });
 

--- a/test/unit/rb-modal-confirm/rb-modal-confirm.spec.js
+++ b/test/unit/rb-modal-confirm/rb-modal-confirm.spec.js
@@ -146,6 +146,16 @@ define([
                 isolatedScope.onCancel();
                 expect($scope.myCancelCallback).toHaveBeenCalled();
             });
+
+            it('should take confirm label from the confirm-label attribute', function () {
+                compileTemplate('<rb-modal-confirm confirm-label="Go!"></rb-modal-confirm>');
+                expect(angular.element(element.find('button')[1]).text().trim()).toBe('Go!');
+            });
+
+            it('should take cancel label from the cancel-label attribute', function () {
+                compileTemplate('<rb-modal-confirm cancel-label="Abort!"></rb-modal-confirm>');
+                expect(angular.element(element.find('button')[0]).text().trim()).toBe('Abort!');
+            });
         });
 
     });


### PR DESCRIPTION
Pass in via the `confirm-label` and `cancel-label` attrs. Defaults to `Confirm` and `Cancel`.

Tests updated.

Required for edit campaign form story, as needs custom modal confirm when cancelling. TP https://rockabox.tpondemand.com/entity/9091