### PR TITLE
Stretch `.TextControl` to full width of parent

### DIFF
--- a/src/rb-text-control/rb-text-control.css
+++ b/src/rb-text-control/rb-text-control.css
@@ -50,6 +50,7 @@
 .TextControl {
     display: flex;
     flex-direction: column;
+    width: 100%;
 }
 
 /**


### PR DESCRIPTION
TP: https://rockabox.tpondemand.com/entity/9374

Fixes `rb-select` as a side-effect, as it's currently using `.TextControl` styles.