### PR TITLE
Refactor rb-radio-control to bind to a model

### DIFF
--- a/src/rb-radio-control/demo/demo-ctrl.js
+++ b/src/rb-radio-control/demo/demo-ctrl.js
@@ -3,33 +3,43 @@ define([
 
     // @ngInject
     function demoCtrl ($rootScope, $state, $injector) {
-        this.data = [
+        this.choices = [
             {
-                label: 'Radio label'
+                label: 'Radio label',
+                value: 'radio_label'
             },
             {
-                label: 'Radio invalid'
+                label: 'Radio invalid',
+                value: 'radio_invalid'
             },
             {
                 label: 'Radio disabled',
+                value: 'radio_disabled',
                 disabled: true
             },
             {
                 label: 'Radio required',
+                value: 'radio_required',
                 required: true
             },
             {
                 label: 'Radio checked',
-                checked: true
+                value: 'radio_checked'
             }
         ];
 
-        this.dataRow = [];
+        this.selected = 'radio_checked';
+
+        this.choicesRow = [];
         for (var i = 0; i < 6; i++) {
-            this.dataRow.push({
-                label: 'Radio label ' + (i + 1)
+            this.choicesRow.push({
+                label: 'Radio label ' + (i + 1),
+                value: 'radio_label_' + (i + 1)
             });
         }
+
+        this.selectedRow = '';
+
     }
 
     return demoCtrl;

--- a/src/rb-radio-control/demo/demo.tpl.html
+++ b/src/rb-radio-control/demo/demo.tpl.html
@@ -38,12 +38,15 @@
     <div class="ComponentView">
         <form name="radioForm">
             <rb-radio-control
-                data="demoCtrl.data"
+                choices="demoCtrl.choices"
+                ng-model="demoCtrl.selected"
                 form="radioForm"
                 help-message="Optional group help message"
                 is-required=true
                 name="ng-radio-group">
             </rb-radio-control>
+
+            Model: {{ demoCtrl.selected }}
         </form>
     </div>
     <div class="RawHTML">
@@ -54,12 +57,15 @@
     <div class="ComponentView">
         <form name="radioRowForm">
             <rb-radio-control
-                data="demoCtrl.dataRow"
+                choices="demoCtrl.choicesRow"
+                ng-model="demoCtrl.selectedRow"
                 form="radioRowForm"
                 help-message="Optional group help message"
                 is-row=true
                 name="ng-radio--row-group">
             </rb-radio-control>
+
+            Model: {{ demoCtrl.selectedRow }}
         </form>
     </div>
 

--- a/src/rb-radio-control/rb-radio-control-directive.js
+++ b/src/rb-radio-control/rb-radio-control-directive.js
@@ -23,7 +23,8 @@ define([
 
         return {
             scope: {
-                data: '=',
+                choices: '=',
+                ngModel: '=',
                 form: '=',
                 helpMessage: '@',
                 isDisabled: '@',
@@ -33,7 +34,16 @@ define([
             },
             restrict: 'E',
             replace: true,
-            template: template
+            template: template,
+            link: function (scope) {
+                scope.setChoice = function (choice) {
+                    scope.ngModel = choice.value;
+                };
+
+                scope.isChecked = function (choice) {
+                    return scope.ngModel === choice.value;
+                };
+            }
         };
     }
 

--- a/src/rb-radio-control/rb-radio-control.tpl.html
+++ b/src/rb-radio-control/rb-radio-control.tpl.html
@@ -10,23 +10,24 @@
                 'is-invalid': form[name].$touched && form[name].$invalid,
                 'is-required': isRequired
             }"
-            ng-repeat="(key, value) in ::data">
+            ng-repeat="(id, choice) in ::choices">
 
             <input
                 class="RadioControl-field"
-                id="{{::name}}-{{::key}}"
+                id="{{::name}}-{{::id}}"
                 name="{{::name}}"
-                ng-checked="{{value.checked}}"
+                ng-click="setChoice(choice)"
                 ng-class="{'is-invalid': form[name].$touched && form[name].$invalid}"
-                ng-disabled="{{::isDisabled || value.disabled}}"
-                ng-required="{{::isRequired || value.required}}"
-                value="{{::value.value}}"
+                ng-disabled="{{::isDisabled || choice.disabled}}"
+                ng-required="{{::isRequired || choice.required}}"
+                ng-checked="isChecked(choice)"
+                value="{{::choice.value}}"
                 type="radio">
 
             <label
                 class="RadioControl-label u-textLabel"
-                for="{{::name}}-{{::key}}">
-                {{::value.label}}
+                for="{{::name}}-{{::id}}">
+                {{::choice.label}}
             </label>
         </div>
     </div>

--- a/test/unit/rb-radio-control/rb-radio-control.spec.js
+++ b/test/unit/rb-radio-control/rb-radio-control.spec.js
@@ -9,14 +9,8 @@ define([
             $compile,
             element,
             compileTemplate,
-            data = [
-                {
-                    label: 'Radio One'
-                },
-                {
-                    label: 'Radio Two'
-                }
-            ];
+            choices,
+            model;
 
         beforeEach(angular.mock.module(rbRadioControl.name));
 
@@ -25,9 +19,21 @@ define([
             $scope = _$rootScope_.$new({});
             $compile = _$compile_;
 
+            choices = [
+                {
+                    label: 'Radio One',
+                    value: 'radio_one'
+                },
+                {
+                    label: 'Radio Two',
+                    value: 'radio_two'
+                }
+            ];
+
             // Compile directive, apply scope and fetch new isolated scope
             compileTemplate = function (template) {
-                $scope.data = data;
+                $scope.choices = choices;
+                $scope.model = model;
                 element = $compile(template)($scope);
                 $scope.$apply();
                 isolatedScope = element.isolateScope();
@@ -35,7 +41,7 @@ define([
         }));
 
         it('should have a name attribute', function () {
-            compileTemplate('<rb-radio-control data="data" name="radio-group"></rb-radio-control>');
+            compileTemplate('<rb-radio-control choices="choices" name="radio-group"></rb-radio-control>');
 
             var radio = element.find('input');
 
@@ -46,7 +52,7 @@ define([
 
         describe('is required', function () {
             it('should not be there by default', function () {
-                compileTemplate('<rb-radio-control data="data"></rb-radio-control>');
+                compileTemplate('<rb-radio-control choices="choices"></rb-radio-control>');
 
                 var radio = element.find('input');
 
@@ -56,7 +62,7 @@ define([
             });
 
             it('should be applied to all radio inputs', function () {
-                compileTemplate('<rb-radio-control data="data" is-required=true></rb-radio-control>');
+                compileTemplate('<rb-radio-control choices="choices" is-required=true></rb-radio-control>');
 
                 var radio = element.find('input');
 
@@ -67,8 +73,8 @@ define([
         });
 
         describe('disabled', function () {
-            it('should enabled by default', function () {
-                compileTemplate('<rb-radio-control data="data"></rb-radio-control>');
+            it('should be enabled by default', function () {
+                compileTemplate('<rb-radio-control choices="choices"></rb-radio-control>');
 
                 var radio = element.find('input');
 
@@ -78,7 +84,7 @@ define([
             });
 
             it('should disable all radio inputs', function () {
-                compileTemplate('<rb-radio-control data="data" is-disabled=true></rb-radio-control>');
+                compileTemplate('<rb-radio-control choices="choices" is-disabled=true></rb-radio-control>');
 
                 var radio = element.find('input');
 
@@ -88,9 +94,9 @@ define([
             });
 
             it('should only disable the first radio input', function () {
-                data[0].disabled = true;
+                choices[0].disabled = true;
 
-                compileTemplate('<rb-radio-control data="data"></rb-radio-control>');
+                compileTemplate('<rb-radio-control choices="choices"></rb-radio-control>');
 
                 var radio = element.find('input');
 
@@ -129,6 +135,24 @@ define([
                 compileTemplate('<rb-radio-control is-row=true></rb-radio-control>');
 
                 expect(angular.element(element[0]).hasClass('RadioControl--row')).toBe(true);
+            });
+        });
+
+        describe('model', function () {
+            it('should be the value of the selected radio control', function () {
+                compileTemplate('<rb-radio-control ng-model="model" choices="choices"></rb-radio-control>');
+
+                isolatedScope.setChoice($scope.choices[0]);
+                $scope.$digest();
+
+                expect($scope.model).toBe(element.find('input')[0].value);
+            });
+
+            it('should select a radio control when already has a value', function () {
+                model = 'radio_two';
+                compileTemplate('<rb-radio-control ng-model="model" choices="choices"></rb-radio-control>');
+
+                expect(isolatedScope.isChecked($scope.choices[1])).toBe(true);
             });
         });
     });


### PR DESCRIPTION
- Model is bound by `ng-model` attribute
- `data` attribute has become `choices`
- The model will be the value of the selected checkbox
- Updated in demos
- Added tests for model binding