### PR TITLE
Fix `.TextControl` required state

### DIFF
--- a/src/rb-text-control/images/Control-required.svg
+++ b/src/rb-text-control/images/Control-required.svg
@@ -1,1 +1,1 @@
-<svg width="4" height="4" viewBox="0 0 4 4" xmlns="http://www.w3.org/2000/svg"><title>required</title><desc>Created with Sketch.</desc><circle fill="#39BE89" cx="2" cy="2" r="2" fill-rule="evenodd"/></svg>
+<svg width="4" height="4" viewBox="0 0 4 4" xmlns="http://www.w3.org/2000/svg"><title>required</title><desc>Created with Sketch.</desc><circle fill="#468EE4" cx="2" cy="2" r="2" fill-rule="evenodd"/></svg>

--- a/src/rb-text-control/rb-text-control.css
+++ b/src/rb-text-control/rb-text-control.css
@@ -20,7 +20,7 @@
     --TextControl-field-disabled-color: var(--color-gray-regent);
     --TextControl-field-disabled-image: "./images/Control-disabled.svg";
     --TextControl-field-disabled-image-position: calc(100% - 12px) center;
-    --TextControl-field-focus-border-color: var(--color-green-base);
+    --TextControl-field-focus-border-color: var(--color-blue-base);
     --TextControl-field-image-padding: 2.5em;
     --TextControl-field-invalid-border-color: var(--color-red-base);
     --TextControl-field-invalid-color: var(--color-red-base);


### PR DESCRIPTION
TP: https://rockabox.tpondemand.com/entity/9473

Required state should be blue, not green. This fixes the outline and corresponding image.

Note that this doesn't fix the weird clashes between Angular and browser validation, so may sometimes see a blue required icon with a red field outline. Will address this in a future story.