### PR TITLE
Add `.SelectControl` styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
-- Nothing.
+- [Basic `.SelectControl` styles](https://github.com/rockabox/rbx_ui_components/pull/146)
 
 ## [1.1.0] - 2015-05-21
 

--- a/src/rb-select-control/demo/demo.tpl.html
+++ b/src/rb-select-control/demo/demo.tpl.html
@@ -1,10 +1,94 @@
-
 <section class="Section">
     <form name="userForm">
         <div class="RawHTML">
             <h2>
                 rb-select-control
             </h2>
+            <h3>
+                Static Test
+            </h3>
+        </div>
+        <div class="ComponentView">
+            <div class="SelectControl">
+                <label class="SelectControl-label u-textLabel" for="SelectDemo">
+                    Normal
+                </label>
+                <select class="SelectControl-field" id="SelectDemo">
+                    <option value="">Car</option>
+                    <option value="0" label="Volvo">Volvo</option>
+                    <option value="1" label="Audi">Audi</option>
+                    <option value="2" label="BMW">BMW</option>
+                    <option value="3" label="Mercedes">Mercedes</option>
+                </select>
+                <div class="SelectControl-message">
+                    i.e. Your favourite make
+                </div>
+            </div>
+            <div class="SelectControl SelectControl--small">
+                <label class="SelectControl-label u-textLabel" for="SelectDemo">
+                    Small
+                </label>
+                <select class="SelectControl-field" id="SelectDemo">
+                    <option value="">Car</option>
+                    <option value="0" label="Volvo">Volvo</option>
+                    <option value="1" label="Audi">Audi</option>
+                    <option value="2" label="BMW">BMW</option>
+                    <option value="3" label="Mercedes">Mercedes</option>
+                </select>
+                <div class="SelectControl-message">
+                    i.e. Your favourite make
+                </div>
+            </div>
+            <div class="SelectControl is-required">
+                <label class="SelectControl-label is-required u-textLabel" for="SelectDemoInvalid">
+                    Required
+                </label>
+                <select class="SelectControl-field is-required" id="SelectDemoInvalid" required>
+                    <option value="">Car</option>
+                    <option value="0" label="Volvo">Volvo</option>
+                    <option value="1" label="Audi">Audi</option>
+                    <option value="2" label="BMW">BMW</option>
+                    <option value="3" label="Mercedes">Mercedes</option>
+                </select>
+                <div class="SelectControl-message is-required">
+                    i.e. Your favourite make
+                </div>
+            </div>
+            <div class="SelectControl is-invalid">
+                <label class="SelectControl-label is-invalid u-textLabel" for="SelectDemoInvalid">
+                    Invalid
+                </label>
+                <select class="SelectControl-field is-invalid" id="SelectDemoInvalid">
+                    <option value="">Car</option>
+                    <option value="0" label="Volvo">Volvo</option>
+                    <option value="1" label="Audi">Audi</option>
+                    <option value="2" label="BMW">BMW</option>
+                    <option value="3" label="Mercedes">Mercedes</option>
+                </select>
+                <div class="SelectControl-message is-invalid">
+                    i.e. Your favourite make
+                </div>
+            </div>
+            <div class="SelectControl is-disabled">
+                <label class="SelectControl-label is-disabled u-textLabel" for="SelectDemoInvalid">
+                    Invalid
+                </label>
+                <select class="SelectControl-field is-disabled" id="SelectDemoInvalid" disabled>
+                    <option value="">Car</option>
+                    <option value="0" label="Volvo">Volvo</option>
+                    <option value="1" label="Audi">Audi</option>
+                    <option value="2" label="BMW">BMW</option>
+                    <option value="3" label="Mercedes">Mercedes</option>
+                </select>
+                <div class="SelectControl-message is-disabled">
+                    i.e. Your favourite make
+                </div>
+            </div>
+        </div>
+        <div class="RawHTML">
+            <h3>
+                Current Angular Version
+            </h3>
         </div>
         <div class="ComponentView">
             <rb-select-control

--- a/src/rb-select-control/demo/demo.tpl.html
+++ b/src/rb-select-control/demo/demo.tpl.html
@@ -66,7 +66,7 @@
                     <option value="3" label="Mercedes">Mercedes</option>
                 </select>
                 <div class="SelectControl-message is-invalid">
-                    i.e. Your favourite make
+                    This field is required.
                 </div>
             </div>
             <div class="SelectControl is-disabled">

--- a/src/rb-select-control/images/Control-disabled.svg
+++ b/src/rb-select-control/images/Control-disabled.svg
@@ -1,0 +1,1 @@
+<svg width="40" height="80" viewBox="0 0 40 80" xmlns="http://www.w3.org/2000/svg"><title>Control-disabled</title><g fill="none" fill-rule="evenodd"><path fill="#F1F4F8" d="M0 0h40v80H0z"/><path fill="#C4CCD7" d="M0 0h1v80H0zM23.5 39v-.5c0-1.38-1.12-2.5-2.5-2.5s-2.5 1.12-2.5 2.5v.5H18v5h6v-5h-.5zm-2 3.5h-1v-2h1v2zm1-3.5h-3v-.5c0-.83.67-1.5 1.5-1.5s1.5.67 1.5 1.5v.5z"/></g></svg>

--- a/src/rb-select-control/images/Control-required-invalid.svg
+++ b/src/rb-select-control/images/Control-required-invalid.svg
@@ -1,0 +1,1 @@
+<svg width="4" height="4" viewBox="0 0 4 4" xmlns="http://www.w3.org/2000/svg"><title>Control-required</title><desc>Created with Sketch.</desc><g fill="none" fill-rule="evenodd"><g fill="#C24A4A"><circle cx="2" cy="2" r="2"/></g></g></svg>

--- a/src/rb-select-control/images/Control-required.svg
+++ b/src/rb-select-control/images/Control-required.svg
@@ -1,0 +1,1 @@
+<svg width="4" height="4" viewBox="0 0 4 4" xmlns="http://www.w3.org/2000/svg"><title>required</title><desc>Created with Sketch.</desc><circle fill="#468EE4" cx="2" cy="2" r="2" fill-rule="evenodd"/></svg>

--- a/src/rb-select-control/images/Control.svg
+++ b/src/rb-select-control/images/Control.svg
@@ -1,0 +1,1 @@
+<svg width="40" height="80" viewBox="0 0 40 80" xmlns="http://www.w3.org/2000/svg"><title>Control</title><g fill="none" fill-rule="evenodd"><path fill="#F1F4F8" d="M0 0h40v80H0z"/><path fill="#C4CCD7" d="M0 0h1v80H0z"/><path d="M20.5 42.764l3.5-3.54-.944-.95-2.556 2.58-2.556-2.58-.944.95 3.5 3.54z" fill="#468EE4"/></g></svg>

--- a/src/rb-select-control/rb-select-control.css
+++ b/src/rb-select-control/rb-select-control.css
@@ -55,6 +55,15 @@
     padding: 0.75em 0.75em 0.5em;
 }
 
+/**
+ * Disable Mozilla focusring styles, use custom focus styles.
+ */
+
+.SelectControl-field:-moz-focusring {
+    color: transparent;
+    text-shadow: 0 0 0 var(--color-gray-shark);
+}
+
 .SelectControl-field:focus,
 .SelectControl-field.is-focused {
     border-color: var(--SelectControl-field-focus-border-color);

--- a/src/rb-select-control/rb-select-control.css
+++ b/src/rb-select-control/rb-select-control.css
@@ -5,12 +5,117 @@
  */
 
 :root {
-    --SelectControl-variable: var();
+    --SelectControl-field-background-color: var(--color-form-field-background);
+    --SelectControl-field-border-color: var(--color-gray-ghost);
+    --SelectControl-field-border-radius: 4px;
+    --SelectControl-field-color: var(--color-gray-tuna);
+    --SelectControl-field-disabled-background-color: var(--color-white-catskill);
+    --SelectControl-field-disabled-color: var(--color-gray-regent);
+    --SelectControl-field-disabled-image: "./images/Control-disabled.svg";
+    --SelectControl-field-disabled-image-position: right center;
+    --SelectControl-field-focus-border-color: var(--color-blue-base);
+    --SelectControl-field-image: "./images/Control.svg";
+    --SelectControl-field-invalid-border-color: var(--color-red-base);
+    --SelectControl-field-required-image: "./images/Control-required.svg";
+    --SelectControl-field-required-image-position: right 45px top 6px;
+    --SelectControl-field-required-invalid-image: "./images/Control-required-invalid.svg";
+    --SelectControl-label-invalid-color: var(--color-red-base);
+    --SelectControl-message-invalid-background-color: var(--color-red-base);
+    --SelectControl-message-invalid-color: var(--color-white);
 }
 
 /**
- * 1. Comment
+ * 1. Remove default appearance. Prefixed versions necessary, see: http://git.io/vTwoV
+ * 2. Set consistent spacing after every field.
+ * 3. Remove `outline` in favour of `border`.
+ * 4. Nudge `required` indicator from top right corner.
+ * 5. Disabled state always overrides other states.
+ * 6. Prevent text selection on disabled field.
  */
 
 .SelectControl {
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+}
+
+/**
+ * Default
+ */
+
+.SelectControl-field {
+    -moz-appearance: none;
+    -webkit-appearance: none;
+    appearance: none; /* 1 */
+    background: var(--SelectControl-field-background-color) url(var(--SelectControl-field-image)) no-repeat center right;
+    border: 1px solid var(--SelectControl-field-border-color);
+    border-radius: var(--SelectControl-field-border-radius);
+    color: var(--SelectControl-field-color);
+    margin-bottom: 0.5em; /* 2 */
+    padding: 0.75em 0.75em 0.5em;
+}
+
+.SelectControl-field:focus,
+.SelectControl-field.is-focused {
+    border-color: var(--SelectControl-field-focus-border-color);
+    outline: none; /* 3 */
+}
+
+.SelectControl-message {
+    display: block;
+    font-size: var(--font-size-x-small);
+}
+
+/**
+ * Invalid
+ */
+
+.SelectControl-label.is-invalid {
+    color: var(--SelectControl-label-invalid-color);
+}
+
+.SelectControl-field:invalid:focus,
+.SelectControl-field.is-invalid {
+    border-color: var(--SelectControl-field-invalid-border-color);
+}
+
+.SelectControl-message.is-invalid {
+    background: var(--SelectControl-message-invalid-background-color);
+    border-radius: var(--SelectControl-field-border-radius);
+    color: var(--SelectControl-message-invalid-color);
+    padding: 0.75em 0.75em 0.5em;
+}
+
+/**
+ * Required
+ */
+
+.SelectControl-field:required,
+.SelectControl-field.is-required {
+    background-image: url(var(--SelectControl-field-image)), url(var(--SelectControl-field-required-image));
+    background-position: center right, var(--SelectControl-field-required-image-position); /* 4 */
+    outline: none; /* 2 */
+}
+
+/**
+ * Disabled
+ */
+
+.SelectControl-field:disabled,
+.SelectControl-field.is-disabled {
+    -moz-appearance: none;
+    -webkit-appearance: none;
+    appearance: none;
+    background: var(--SelectControl-field-disabled-background-color) url(var(--SelectControl-field-disabled-image)) no-repeat var(--SelectControl-field-disabled-image-position) !important; /* 5 */
+    border: 1px solid var(--SelectControl-field-border-color) !important; /* 5 */
+    color: var(--SelectControl-field-disabled-color) !important; /* 5 */
+    user-select: none; /* 6 */
+}
+
+/**
+ * Small
+ */
+
+.SelectControl--small .SelectControl-field {
+    font-size: var(--font-size-x-small);
 }

--- a/src/rb-select-control/rb-select-control.tpl.html
+++ b/src/rb-select-control/rb-select-control.tpl.html
@@ -1,10 +1,11 @@
-<div class="TextControl TextControl--select">
+<div class="SelectControl">
     <label
-        class="TextControl-label u-textLabel"
+        class="SelectControl-label u-textLabel"
         ng-class="{'is-invalid': form[name].$touched && form[name].$invalid}">
         {{ label }}
     </label>
     <select
+        class="SelectControl-field"
         name="{{name}}"
         ng-options="item[value] as item[display] for item in items"
         ng-model="selected"
@@ -13,16 +14,16 @@
             <option value="" ng-show="placeholder">{{ placeholder }}</option>
     </select>
 
-    <div class="TextControl-message" ng-show="helpMessage">
+    <div class="SelectControl-message" ng-show="helpMessage">
         {{helpMessage}}
     </div>
 
-    <div class="TextControl-message is-invalid" ng-if="form[name].$error.server">
+    <div class="SelectControl-message is-invalid" ng-if="form[name].$error.server">
         {{ form[name].$error.server }}
     </div>
 
     <div ng-if="form[name].$touched">
-        <div class="TextControl-message is-invalid" ng-if="form[name].$error.required">
+        <div class="SelectControl-message is-invalid" ng-if="form[name].$error.required">
             This field is required.
         </div>
     </div>


### PR DESCRIPTION
TP: https://rockabox.tpondemand.com/entity/9179

Temporary, to tide us over until a custom typeahead is built.

Uses the exciting, new(ish) `appearance` property. This should work in Chrome, Firefox,
other Webkit but may fail horribly in IE. C'est la vie.