### PR TITLE
Updated overlay modal demo to just use overlay modal

### DIFF
--- a/src/rb-overlay-modal/demo/demo.tpl.html
+++ b/src/rb-overlay-modal/demo/demo.tpl.html
@@ -128,10 +128,5 @@
     proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
 </p>
 
-<rb-overlay-modal>
-    <rb-modal-confirm title="Are you sure?">
-        <p>
-            You are about to ACTION this ITEM.
-        </p>
-    </rb-modal-confirm>
-</rb-overlay-modal>
+<rb-overlay-modal></rb-overlay-modal>
+


### PR DESCRIPTION
The overlay modal demo was actually using a modal confirm which had a overlay modal within it. Demo now shows overlay modal in isolation.