### PR TITLE
Bump karma jasmine version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - [Basic `.SelectControl` styles](https://github.com/rockabox/rbx_ui_components/pull/146)
 - [Add `basics` modifier to `rb-fieldset` component](https://github.com/rockabox/rbx_ui_components/pull/144). Use instead of `campaignBasics`, which will be removed in a future release.
 
+### Changed
+- [Bumped `karma-jasmine` version to use newer version of `jasmine`](https://github.com/rockabox/rbx_ui_components/pull/154)
+
 ### Fixed
 
 - [Update README](https://github.com/rockabox/rbx_ui_components/pull/145). Tidy up, including accurate dependencies and steps to build.

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "istanbul-instrumenter-loader": "~0.1.2",
     "karma": "~0.12.16",
     "karma-coverage": "~0.2.5",
-    "karma-jasmine": "~0.1.5",
+    "karma-jasmine": "~0.3.5",
     "karma-phantomjs-launcher": "~0.1.4",
     "karma-sourcemap-loader": "~0.3.4",
     "karma-webpack": "~1.5.0",

--- a/test/unit/rb-progress-button/rb-progress-button.spec.js
+++ b/test/unit/rb-progress-button/rb-progress-button.spec.js
@@ -35,7 +35,7 @@ define([
                 });
             };
             isolatedScope.$apply();
-            spyOn(isolatedScope, 'onExecute').andReturn(deferredResolution.promise);
+            spyOn(isolatedScope, 'onExecute').and.returnValue(deferredResolution.promise);
         }));
 
         describe('attribute generation', function () {


### PR DESCRIPTION
Bump karma jasmine version to update jasmine. Fix test using deprecated jasmine API.

Noticed we're using different versions across repo's so just wanted to bring them in line. Updates to jasmine API mainly around spies and running specific tests with `fit` and `fdescribe` rather than `iit` and `ddescribe`

Latest jasmine docs for ref:
http://jasmine.github.io/2.3/introduction.html
