### PR TITLE
Add reporting-specific `rb-fieldset` modifiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 - [Basic `.SelectControl` styles](https://github.com/rockabox/rbx_ui_components/pull/146)
 - [Add `basics` modifier to `rb-fieldset` component](https://github.com/rockabox/rbx_ui_components/pull/144). Use instead of `campaignBasics`, which will be removed in a future release.
+- [`breakdown and `metrics` modifiers for `rb-fieldset` component](https://github.com/rockabox/rbx_ui_components/pull/155). Intended for use in Reporting UI.
 
 ### Fixed
 

--- a/src/rb-fieldset/demo/demo.tpl.html
+++ b/src/rb-fieldset/demo/demo.tpl.html
@@ -108,4 +108,21 @@
             </p>
         </rb-fieldset>
     </div>
+    <div class="RawHTML">
+        <h3>
+            Metrics modifier
+        </h3>
+    </div>
+    <div class="ComponentView">
+        <rb-fieldset type="metrics" title="Metrics">
+            <p>
+                Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod
+                tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,
+                quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+                consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse
+                cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non
+                proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+            </p>
+        </rb-fieldset>
+    </div>
 </section>

--- a/src/rb-fieldset/demo/demo.tpl.html
+++ b/src/rb-fieldset/demo/demo.tpl.html
@@ -59,6 +59,23 @@
     </div>
     <div class="RawHTML">
         <h3>
+            Breakdown modifier
+        </h3>
+    </div>
+    <div class="ComponentView">
+        <rb-fieldset type="breakdown" title="Breakdown">
+            <p>
+                Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod
+                tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,
+                quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+                consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse
+                cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non
+                proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+            </p>
+        </rb-fieldset>
+    </div>
+    <div class="RawHTML">
+        <h3>
             Goals modifier
         </h3>
     </div>

--- a/src/rb-fieldset/images/breakdown.svg
+++ b/src/rb-fieldset/images/breakdown.svg
@@ -1,0 +1,1 @@
+<svg width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><title>breakdown</title><path d="M7 14c-3.877 0-7-3.102-7-6.98C0 3.143 3.143 0 7.02 0 10.898 0 14 3.123 14 7H7v7zm1 2V8h8c0 3.976-4.024 8-8 8z" fill="#35353A" fill-rule="evenodd"/></svg>

--- a/src/rb-fieldset/images/metrics.svg
+++ b/src/rb-fieldset/images/metrics.svg
@@ -1,0 +1,1 @@
+<svg width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><title>breakdown</title><path d="M0 16v-2h16v2H0zM12 0h4v12h-4V0zM6 4h4v8H6V4zM0 8h4v4H0V8z" fill="#35353A" fill-rule="evenodd"/></svg>

--- a/src/rb-fieldset/rb-fieldset.css
+++ b/src/rb-fieldset/rb-fieldset.css
@@ -58,6 +58,17 @@
 }
 
 /**
+ * Breakdown modifier
+ */
+
+.Fieldset--breakdown .Fieldset-title {
+    background-image: url("./images/breakdown.svg");
+    background-position: var(--Fieldset-title-background-position);
+    background-repeat: no-repeat;
+    padding-left: 32px;
+}
+
+/**
  * Finance modifier
  */
 

--- a/src/rb-fieldset/rb-fieldset.css
+++ b/src/rb-fieldset/rb-fieldset.css
@@ -90,6 +90,17 @@
     padding-left: 32px;
 }
 
+/**
+ * Metrics modifier
+ */
+
+.Fieldset--metrics .Fieldset-title {
+    background-image: url("./images/metrics.svg");
+    background-position: var(--Fieldset-title-background-position);
+    background-repeat: no-repeat;
+    padding-left: 32px;
+}
+
 @media (--md-viewport) {
 
     .Fieldset {

--- a/src/rb-fieldset/rb-fieldset.tpl.html
+++ b/src/rb-fieldset/rb-fieldset.tpl.html
@@ -1,6 +1,7 @@
 <div class="Fieldset" ng-class="{
     'Fieldset--additionalInfo': type == 'additionalInfo',
     'Fieldset--basics': type == 'basics' || type == 'campaignBasics',
+    'Fieldset--breakdown': type == 'breakdown',
     'Fieldset--goals': type == 'goals',
     'Fieldset--finance': type == 'finance'
 }">

--- a/src/rb-fieldset/rb-fieldset.tpl.html
+++ b/src/rb-fieldset/rb-fieldset.tpl.html
@@ -3,7 +3,8 @@
     'Fieldset--basics': type == 'basics' || type == 'campaignBasics',
     'Fieldset--breakdown': type == 'breakdown',
     'Fieldset--goals': type == 'goals',
-    'Fieldset--finance': type == 'finance'
+    'Fieldset--finance': type == 'finance',
+    'Fieldset--metrics': type == 'metrics'
 }">
     <div class="Fieldset-title">
         <span class="u-textLegend">{{ ::title }}</span>

--- a/test/unit/rb-fieldset/rb-fieldset.spec.js
+++ b/test/unit/rb-fieldset/rb-fieldset.spec.js
@@ -68,6 +68,12 @@ define([
                 expect(element.hasClass('Fieldset--basics')).toBeTruthy();
             });
 
+            it('should use the breakdown type', function () {
+                compileTemplate('<rb-fieldset title="Default Text" type="breakdown"></rb-fieldset>');
+
+                expect(element.hasClass('Fieldset--breakdown')).toBeTruthy();
+            });
+
             it('should use the campaignBasics type [DEPRECATED]', function () {
                 compileTemplate('<rb-fieldset title="Default Text" type="campaignBasics"></rb-fieldset>');
 

--- a/test/unit/rb-fieldset/rb-fieldset.spec.js
+++ b/test/unit/rb-fieldset/rb-fieldset.spec.js
@@ -85,6 +85,12 @@ define([
 
                 expect(element.hasClass('Fieldset--finance')).toBeTruthy();
             });
+
+            it('should use the metrics type', function () {
+                compileTemplate('<rb-fieldset title="Default Text" type="metrics"></rb-fieldset>');
+
+                expect(element.hasClass('Fieldset--metrics')).toBeTruthy();
+            });
         });
     });
 });


### PR DESCRIPTION
TP: https://rockabox.tpondemand.com/entity/9566

* Breakdown
* Metrics

Note that metrics now uses what was previously the reporting basics fieldset icon. This was an on-the-fly design decision by @freemonster.