### PR TITLE
Add inherit model to datetime control

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,12 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased][unreleased]
 
-### Removed
+### Added
+- [`rb-datetime-control` `inherit-datetime` attribute](https://github.com/rockabox/rbx_ui_components/pull/156). Supercedes `inherit` attribute.
+- [`rb-datetime-control` `inherit-model` optional property attribute](https://github.com/rockabox/rbx_ui_components/pull/156). Date inheritence should be treated as a model.
 
+### Removed
+- [`rb-datetime-control` `inherit` attribute](https://github.com/rockabox/rbx_ui_components/pull/156). Superceded by `inherit-datetime` attribute.
 - [`rb-fieldset` `campaignBasics` modifier](https://github.com/rockabox/rbx_ui_components/pull/169). Superceded by `basics` modifier.
 - [`rb-select` component](https://github.com/rockabox/rbx_ui_components/pull/170). Superceded by `rb-select-control` component.
 

--- a/src/rb-datetime-control/demo/demo-ctrl.js
+++ b/src/rb-datetime-control/demo/demo-ctrl.js
@@ -8,10 +8,12 @@ define([
             'basic': '2015-04-27T11:29:05.474Z',
             'required': '',
             'help': '',
-            'placeholder': ''
+            'placeholder': '',
+            'inheritModelTrue': true,
+            'inheritModel': false
         };
 
-        this.inheritDateTime = '2015-04-27T11:29:05.474Z';
+        this.inherit = '2015-04-27T11:29:05.474Z';
 
     }
 

--- a/src/rb-datetime-control/demo/demo-ctrl.js
+++ b/src/rb-datetime-control/demo/demo-ctrl.js
@@ -13,7 +13,7 @@ define([
             'inheritModel': false
         };
 
-        this.inherit = '2015-04-27T11:29:05.474Z';
+        this.inheritDatetime = '2015-04-27T11:29:05.474Z';
 
     }
 

--- a/src/rb-datetime-control/demo/demo.tpl.html
+++ b/src/rb-datetime-control/demo/demo.tpl.html
@@ -46,7 +46,7 @@
         </div>
         <div class="ComponentView">
             <h4>With inherited date time</h4>
-            <rb-datetime-control name="placeholder" form="basicForm" inherit-label="Inherit date/time from somehwere else." inherit="{{demoCtrl.inheritDateTime}}" placeholder-date="DD/MM/YY" placeholder-time="HH:MM" title="Date time" ng-model="demoCtrl.data.inherit"></rb-datetime-control>
+            <rb-datetime-control name="placeholder" form="basicForm" inherit-label="Inherit date/time from somehwere else." inherit="{{demoCtrl.inherit}}" placeholder-date="DD/MM/YY" placeholder-time="HH:MM" title="Date time" ng-model="demoCtrl.data.inherit" inherit-model='demoCtrl.data.inheritModel'></rb-datetime-control>
 
             <h5>Scope value (UTC):</h5>
             <div hljs language="json">
@@ -54,8 +54,17 @@
             </div>
         </div>
         <div class="ComponentView">
+            <h4>With preset inherited date time</h4>
+            <rb-datetime-control name="placeholder" form="basicForm" inherit-label="Inherit date/time from somehwere else." inherit="{{demoCtrl.inherit}}" placeholder-date="DD/MM/YY" placeholder-time="HH:MM" title="Date time" ng-model="demoCtrl.data.presetInherit" inherit-model='demoCtrl.data.inheritModelTrue'></rb-datetime-control>
+
+            <h5>Scope value (UTC):</h5>
+            <div hljs language="json">
+                {{ demoCtrl.data.presetInherit }}
+            </div>
+        </div>
+        <div class="ComponentView">
             <h4>With inherited date and isDisabled</h4>
-            <rb-datetime-control name="placeholder" is-disabled="true" form="basicForm" inherit-label="Inherit date/time from somehwere else." inherit="{{demoCtrl.inheritDateTime}}" placeholder-date="DD/MM/YY" placeholder-time="HH:MM" title="Date time" ng-model="demoCtrl.data.disabled"></rb-datetime-control>
+            <rb-datetime-control name="placeholder" is-disabled="true" form="basicForm" inherit-label="Inherit date/time from somehwere else." inherit="{{demoCtrl.inherit}}" placeholder-date="DD/MM/YY" placeholder-time="HH:MM" title="Date time" ng-model="demoCtrl.data.disabled"></rb-datetime-control>
 
             <h5>Scope value (UTC):</h5>
             <div hljs language="json">

--- a/src/rb-datetime-control/demo/demo.tpl.html
+++ b/src/rb-datetime-control/demo/demo.tpl.html
@@ -46,7 +46,7 @@
         </div>
         <div class="ComponentView">
             <h4>With inherited date time</h4>
-            <rb-datetime-control name="placeholder" form="basicForm" inherit-label="Inherit date/time from somehwere else." inherit="{{demoCtrl.inherit}}" placeholder-date="DD/MM/YY" placeholder-time="HH:MM" title="Date time" ng-model="demoCtrl.data.inherit" inherit-model='demoCtrl.data.inheritModel'></rb-datetime-control>
+            <rb-datetime-control name="placeholder" form="basicForm" inherit-label="Inherit date/time from somehwere else." inherit-datetime="{{demoCtrl.inheritDatetime}}" placeholder-date="DD/MM/YY" placeholder-time="HH:MM" title="Date time" ng-model="demoCtrl.data.inherit" inherit-model='demoCtrl.data.inheritModel'></rb-datetime-control>
 
             <h5>Scope value (UTC):</h5>
             <div hljs language="json">
@@ -55,7 +55,7 @@
         </div>
         <div class="ComponentView">
             <h4>With preset inherited date time</h4>
-            <rb-datetime-control name="placeholder" form="basicForm" inherit-label="Inherit date/time from somehwere else." inherit="{{demoCtrl.inherit}}" placeholder-date="DD/MM/YY" placeholder-time="HH:MM" title="Date time" ng-model="demoCtrl.data.presetInherit" inherit-model='demoCtrl.data.inheritModelTrue'></rb-datetime-control>
+            <rb-datetime-control name="placeholder" form="basicForm" inherit-label="Inherit date/time from somehwere else." inherit-datetime="{{demoCtrl.inheritDatetime}}" placeholder-date="DD/MM/YY" placeholder-time="HH:MM" title="Date time" ng-model="demoCtrl.data.presetInherit" inherit-model='demoCtrl.data.inheritModelTrue'></rb-datetime-control>
 
             <h5>Scope value (UTC):</h5>
             <div hljs language="json">
@@ -64,7 +64,7 @@
         </div>
         <div class="ComponentView">
             <h4>With inherited date and isDisabled</h4>
-            <rb-datetime-control name="placeholder" is-disabled="true" form="basicForm" inherit-label="Inherit date/time from somehwere else." inherit="{{demoCtrl.inherit}}" placeholder-date="DD/MM/YY" placeholder-time="HH:MM" title="Date time" ng-model="demoCtrl.data.disabled"></rb-datetime-control>
+            <rb-datetime-control name="placeholder" is-disabled="true" form="basicForm" inherit-label="Inherit date/time from somehwere else." inherit-datetime="{{demoCtrl.inheritDatetime}}" placeholder-date="DD/MM/YY" placeholder-time="HH:MM" title="Date time" ng-model="demoCtrl.data.disabled"></rb-datetime-control>
 
             <h5>Scope value (UTC):</h5>
             <div hljs language="json">

--- a/src/rb-datetime-control/rb-datetime-control-directive.js
+++ b/src/rb-datetime-control/rb-datetime-control-directive.js
@@ -39,11 +39,12 @@ define([
                 placeholderDate: '@',
                 placeholderTime: '@',
                 helpMessage: '@',
-                ngModel: '=',
+                ngModel: '=?',
                 form: '=',
                 name: '@',
                 inherit: '@',
-                inheritLabel: '@'
+                inheritLabel: '@',
+                inheritModel: '=?'
             },
             restrict: 'E',
             replace: true,
@@ -55,11 +56,11 @@ define([
 
                 scope.disableInputs = false;
 
-                scope.toggleInherited = function (inheritedDateTime) {
-                    if (scope.inherited) {
-                        scope.ngModel = inheritedDateTime;
+                scope.toggleInherited = function () {
+                    if (scope.inheritModel === true) {
+                        scope.ngModel = scope.inherit;
                         scope.disableInputs = true;
-                    } else {
+                    } else if (scope.inheritModel === false) {
                         scope.ngModel = '';
                         scope.disableInputs = false;
                     }
@@ -69,6 +70,11 @@ define([
                     // This doesn't seem to work inside ng-disabled?
                     return scope.disableInputs || scope.isDisabled === 'true';
                 };
+
+                scope.$watch('inheritModel', function (newVal) {
+                    scope.toggleInherited();
+                }, true);
+
             }
         };
     }

--- a/src/rb-datetime-control/rb-datetime-control-directive.js
+++ b/src/rb-datetime-control/rb-datetime-control-directive.js
@@ -42,7 +42,7 @@ define([
                 ngModel: '=?',
                 form: '=',
                 name: '@',
-                inherit: '@',
+                inheritDatetime: '@',
                 inheritLabel: '@',
                 inheritModel: '=?'
             },
@@ -58,7 +58,7 @@ define([
 
                 scope.toggleInherited = function () {
                     if (scope.inheritModel === true) {
-                        scope.ngModel = scope.inherit;
+                        scope.ngModel = scope.inheritDatetime;
                         scope.disableInputs = true;
                     } else if (scope.inheritModel === false) {
                         scope.ngModel = '';

--- a/src/rb-datetime-control/rb-datetime-control.tpl.html
+++ b/src/rb-datetime-control/rb-datetime-control.tpl.html
@@ -31,7 +31,7 @@
 
     <div class="DatetimeControl-inherit" ng-show="inherit">
         <label>{{ inheritLabel }}</label>
-        <input ng-model="inherited" ng-change="toggleInherited(inherit)" type="checkbox" ng-disabled="{{ isDisabled }}">
+        <input ng-model="inheritModel" type="checkbox" ng-disabled="{{ isDisabled }}">
     </div>
 
     <div class="TextControl-message" ng-show="helpMessage">

--- a/src/rb-datetime-control/rb-datetime-control.tpl.html
+++ b/src/rb-datetime-control/rb-datetime-control.tpl.html
@@ -29,7 +29,7 @@
         autocomplete="off"
         bs-timepicker>
 
-    <div class="DatetimeControl-inherit" ng-show="inherit">
+    <div class="DatetimeControl-inherit" ng-show="inheritDatetime">
         <label>{{ inheritLabel }}</label>
         <input ng-model="inheritModel" type="checkbox" ng-disabled="{{ isDisabled }}">
     </div>

--- a/test/unit/rb-datetime-control/rb-datetime-control.spec.js
+++ b/test/unit/rb-datetime-control/rb-datetime-control.spec.js
@@ -290,6 +290,28 @@ define([
                 // Timezone should be set with TZ=UTC flag before running tests so phamtom doesn't use local timzone.
                 expect(element.find('input')[1].value).toBe('');
             });
+
+            it('should bind as a boolean to the inherit-model attribute', function () {
+                $scope.inheritModel = true;
+                $scope.inheritDateTime = '2015-04-27T11:29:05.474Z';
+                $scope.dt = '';
+                compileTemplate(
+                    '<rb-datetime-control name="test" ng-model="dt" inherit-datetime="{{inheritDateTime}}"' +
+                    ' is-required="true" inherit-model="inheritModel" form="aForm"></rb-datetime-control>'
+                );
+
+                isolatedScope.toggleInherited();
+                isolatedScope.$apply();
+
+                var inputOne = angular.element(element.find('input')[0]),
+                    inputTwo = angular.element(element.find('input')[1]);
+
+                expect(inputOne[0].value).toBe('27/04/2015');
+                expect(inputOne.attr('disabled')).toBe('disabled');
+                // Timezone should be set with TZ=UTC flag before running tests so phamtom doesn't use local timzone.
+                expect(inputTwo[0].value).toBe('11:29');
+                expect(inputTwo.attr('disabled')).toBe('disabled');
+            });
         });
 
         describe('validation', function () {

--- a/test/unit/rb-datetime-control/rb-datetime-control.spec.js
+++ b/test/unit/rb-datetime-control/rb-datetime-control.spec.js
@@ -224,11 +224,11 @@ define([
                 expect(angular.element(inheritDiv).hasClass('ng-hide')).toBe(true);
             });
 
-            it('should show inherited date time checkbox when attribute is specified', function () {
-                $scope.inherited = '2015-04-27T11:29:05.474Z';
+            it('should show inherited date time checkbox when inherit-datetime attribute is specified', function () {
+                $scope.inheritDateTime = '2015-04-27T11:29:05.474Z';
                 compileTemplate(
-                    '<rb-datetime-control name="test" inherit="{{inherited}}" is-required="true" form="aForm">' +
-                    '</rb-datetime-control>'
+                    '<rb-datetime-control name="test" inherit-datetime="{{inheritDateTime}}" is-required="true" ' +
+                    'form="aForm"></rb-datetime-control>'
                 );
 
                 var inheritDiv = element[0].getElementsByClassName('DatetimeControl-inherit')[0];
@@ -237,10 +237,10 @@ define([
             });
 
             it('should set inherit label passed from attribute', function () {
-                $scope.inherited = '2015-04-27T11:29:05.474Z';
+                $scope.inheritDateTime = '2015-04-27T11:29:05.474Z';
                 compileTemplate(
-                    '<rb-datetime-control name="test" inherit-label="Inherit date/time" inherit="{{inherited}}"' +
-                    ' is-required="true" form="aForm"></rb-datetime-control>'
+                    '<rb-datetime-control name="test" inherit-label="Inherit date/time" ' +
+                    'inherit-datetime="{{inheritDateTime}}" is-required="true" form="aForm"></rb-datetime-control>'
                 );
 
                 var inheritDiv = element[0].getElementsByClassName('DatetimeControl-inherit')[0];
@@ -249,15 +249,17 @@ define([
             });
 
             it('should set date to inherited date value on checkbox select', function () {
-                $scope.inherited = '2015-04-27T11:29:05.474Z';
+                $scope.inheritModel = false;
+                $scope.inheritDateTime = '2015-04-27T11:29:05.474Z';
                 $scope.dt = '';
                 compileTemplate(
-                    '<rb-datetime-control name="test" ng-model="dt" inherit="{{inherited}}" is-required="true"' +
-                    ' form="aForm"></rb-datetime-control>'
+                    '<rb-datetime-control name="test" ng-model="dt" inherit-datetime="{{inheritDateTime}}" ' +
+                    'is-required="true" inherit-model="inheritModel" form="aForm"></rb-datetime-control>'
                 );
 
-                isolatedScope.inherited = true;
-                isolatedScope.toggleInherited($scope.inherited);
+                $scope.inheritModel = true;
+                $scope.$apply();
+                isolatedScope.toggleInherited();
                 isolatedScope.$apply();
 
                 var inputOne = angular.element(element.find('input')[0]),
@@ -271,15 +273,17 @@ define([
             });
 
             it('should set date to a emtpy value on checkbox deselect', function () {
-                $scope.inherited = '2015-04-27T11:29:05.474Z';
+                $scope.inheritModel = true;
+                $scope.inheritDateTime = '2015-04-27T11:29:05.474Z';
                 $scope.dt = '';
                 compileTemplate(
-                    '<rb-datetime-control name="test" ng-model="dt" inherit="{{inherited}}" is-required="true"' +
-                    ' form="aForm"></rb-datetime-control>'
+                    '<rb-datetime-control name="test" ng-model="dt" inherit-datetime="{{inheritDateTime}}" ' +
+                    'is-required="true" inherit-model="inheritModel" form="aForm"></rb-datetime-control>'
                 );
 
-                isolatedScope.inherited = false;
-                isolatedScope.toggleInherited($scope.inherited);
+                $scope.inheritModel = false;
+                $scope.$apply();
+                isolatedScope.toggleInherited();
                 isolatedScope.$apply();
 
                 expect(element.find('input')[0].value).toBe('');


### PR DESCRIPTION
- New property attribute `inherit-model` with binding test
- Renamed `inherit` to `inherit-date-time` as property rename confusing with fixed tests
- Updated demos

TP https://rockabox.tpondemand.com/entity/9562