### PR TITLE
Prevent PhantomJs timeouts when running tests on Travis CI

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -37,6 +37,10 @@ module.exports = function (config) {
         runnerPort: 9100,
         autoWatch: true,
         captureTimeout: 60000,
+        // to avoid DISCONNECTED messages
+        browserDisconnectTimeout: 10000, // default 2000
+        browserDisconnectTolerance: 1, // default 0
+        browserNoActivityTimeout: 60000, //default 10000
         singleRun: true,
         webpack: webpackConfig
     });


### PR DESCRIPTION
Hopefully. See:

* karma-runner/karma#598
* webpack/karma-webpack#8