### PR TITLE
Update `rb-currency` demo

### DIFF
--- a/src/rb-currency/demo/demo.tpl.html
+++ b/src/rb-currency/demo/demo.tpl.html
@@ -1,23 +1,57 @@
-<div>
-    Currency with decimal: <rb-currency amount="{{ demoCtrl.currency.withDec }}"></rb-currency>
-</div>
-
-<div>
-    Currency without decimal passed: <rb-currency amount="{{ demoCtrl.currency.withoutDec }}"></rb-currency>
-</div>
-
-<div>
-    Currency with 0 decimal passed (rounded): <rb-currency decimal-places="0" amount="{{ demoCtrl.currency.withDec }}"></rb-currency>
-</div>
-
-<div>
-    Currency with 1 decimal place: <rb-currency decimal-places="1" amount="{{ demoCtrl.currency.roundDec }}"></rb-currency>
-</div>
-
-<div>
-    Currency with 2 decimal place: <rb-currency decimal-places="2" amount="{{ demoCtrl.currency.roundDec }}"></rb-currency>
-</div>
-
-<div>
-    Currency with 3 decimal places: <rb-currency decimal-places="3" amount="{{ demoCtrl.currency.roundDec }}"></rb-currency>
-</div>
+<section class="Section">
+    <div class="RawHTML">
+        <h2>
+            rb-currency
+        </h2>
+        <p>
+            The <code>rb-currency</code> component must be used to render all representations of a currency. It should
+            not be used for any other type of number.
+        </p>
+        <h3>
+            Currency With Decimal Passed
+        </h3>
+    </div>
+    <div class="ComponentView">
+        <rb-currency amount="{{ demoCtrl.currency.withDec }}"></rb-currency>
+    </div>
+    <div class="RawHTML">
+        <h3>
+            Currency With No Decimal Passed
+        </h3>
+    </div>
+    <div class="ComponentView">
+        <rb-currency amount="{{ demoCtrl.currency.withoutDec }}"></rb-currency>
+    </div>
+    <div class="RawHTML">
+        <h3>
+            Currency With 0 Passed As Decimal (Rounded)
+        </h3>
+    </div>
+    <div class="ComponentView">
+        <rb-currency decimal-places="0" amount="{{ demoCtrl.currency.withDec }}"></rb-currency>
+    </div>
+    <div class="RawHTML">
+        <h3>
+            Currency With 1 Decimal Place
+        </h3>
+    </div>
+    <div class="ComponentView">
+        <rb-currency decimal-places="1" amount="{{ demoCtrl.currency.roundDec }}"></rb-currency>
+    </div>
+    <div class="RawHTML">
+        <h3>
+            Currency With 2 Decimal Places
+        </h3>
+    </div>
+    <div class="ComponentView">
+        <rb-currency decimal-places="2" amount="{{ demoCtrl.currency.roundDec }}"></rb-currency>
+    </div>
+    <div class="RawHTML">
+        <h3>
+            Currency With 3 Decimal Places
+        </h3>
+    </div>
+    <div class="ComponentView">
+        <rb-currency decimal-places="3" amount="{{ demoCtrl.currency.roundDec }}"></rb-currency>
+    </div>
+</section>


### PR DESCRIPTION
An updated version of the old docs from style guide.

Ditching a few specifics: 

* We don't need to specify `<data>` as the root element, it's now part of the component template.
* The decimal place information in style guide is out of date.
* [Style.ONS](http://style.ons.gov.uk/numbers/money/) makes sense with numbers in text, but not so much as a component.