### PR TITLE
Rename `.Login` to `.LoginForm`

### DIFF
--- a/src/rb-login-form/rb-login-form.css
+++ b/src/rb-login-form/rb-login-form.css
@@ -1,30 +1,30 @@
-/** @define Login; use strict */
+/** @define LoginForm; use strict */
 
 /**
- * The `.Login` component is a composed form component.
+ * The `.LoginForm` component is a composed form component.
  */
 
 :root {
-    --Login-color: var(--color-white-alabaster);
+    --LoginForm-color: var(--color-white-alabaster);
 }
 
 /**
  * 1. Comment
  */
 
-.Login {
-    color: var(--Login-color);
+.LoginForm {
+    color: var(--LoginForm-color);
 }
 
-.Login-icon {
+.LoginForm-icon {
     margin: 0 2.75em 2.25em;
     text-align: center;
 }
 
-.Login-control {
+.LoginForm-control {
     margin-bottom: 0.25em;
 }
 
-.Login-button {
+.LoginForm-button {
     margin-top: 1em;
 }

--- a/src/rb-login-form/rb-login-form.tpl.html
+++ b/src/rb-login-form/rb-login-form.tpl.html
@@ -1,10 +1,10 @@
-<div class="Login">
-    <div class="Login-icon">
+<div class="LoginForm">
+    <div class="LoginForm-icon">
         <rb-icon icon="{{::icon}}"></rb-icon>
     </div>
-    <form name="loginForm" class="Login-body">
+    <form name="loginForm" class="LoginForm-body">
         <fieldset>
-            <div class="Login-control">
+            <div class="LoginForm-control">
                 <rb-text-control
                     form="loginForm"
                     title="Email"
@@ -15,7 +15,7 @@
                     is-required="true">
                 </rb-text-control>
             </div>
-            <div class="Login-control">
+            <div class="LoginForm-control">
                 <rb-text-control
                     form="loginForm"
                     title="Password"
@@ -28,7 +28,7 @@
             </div>
         </fieldset>
         <rb-form-message ng-if="message">{{ message }}</rb-form-message>
-        <fieldset class="Login-button">
+        <fieldset class="LoginForm-button">
             <rb-button block="yes" state="positive" ng-disabled="loginForm.$invalid" ng-click="onLogin()">Login</rb-button>
         </fieldset>
     </form>


### PR DESCRIPTION
TP: https://rockabox.tpondemand.com/entity/9587

Make consistent with component name `rb-login-form` and approach used with `rb-generic-form` / `.GenericForm`.

Keeping this out of the change log as the change isn't exposed outside the component.