### PR TITLE
Preserve original model when inheriting datetime in rb-datetime-control

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ For multiple checkboxes use `rb-check-control-group` instead of `rb-check-contro
 - [`rb-fieldset` `campaignBasics` modifier](https://github.com/rockabox/rbx_ui_components/pull/169). Superceded by `basics` modifier.
 - [`rb-select` component](https://github.com/rockabox/rbx_ui_components/pull/170). Superceded by `rb-select-control` component.
 
+### Fixed
+- [`rb-datetime-control` `ng-model` preservation when inheriting datetime](https://github.com/rockabox/rbx_ui_components/pull/173).
+
 ## [1.2.0] - 2015-05-29
 
 ### Added

--- a/src/rb-datetime-control/demo/demo-ctrl.js
+++ b/src/rb-datetime-control/demo/demo-ctrl.js
@@ -10,7 +10,9 @@ define([
             'help': '',
             'placeholder': '',
             'inheritModelTrue': true,
-            'inheritModel': false
+            'inheritModel': false,
+            'inherit': '2015-05-10T09:15:02.474Z',
+            'presetInherit': '2015-05-10T09:15:02.474Z'
         };
 
         this.inheritDatetime = '2015-04-27T11:29:05.474Z';

--- a/src/rb-datetime-control/rb-datetime-control-directive.js
+++ b/src/rb-datetime-control/rb-datetime-control-directive.js
@@ -56,12 +56,15 @@ define([
 
                 scope.disableInputs = false;
 
+                var originalNgModel = angular.copy(scope.ngModel);
+
                 scope.toggleInherited = function () {
                     if (scope.inheritModel === true) {
+                        originalNgModel = angular.copy(scope.ngModel);
                         scope.ngModel = scope.inheritDatetime;
                         scope.disableInputs = true;
                     } else if (scope.inheritModel === false) {
-                        scope.ngModel = '';
+                        scope.ngModel = originalNgModel;
                         scope.disableInputs = false;
                     }
                 };

--- a/test/unit/rb-datetime-control/rb-datetime-control.spec.js
+++ b/test/unit/rb-datetime-control/rb-datetime-control.spec.js
@@ -312,6 +312,27 @@ define([
                 expect(inputTwo[0].value).toBe('11:29');
                 expect(inputTwo.attr('disabled')).toBe('disabled');
             });
+
+            it('should restore original ng-model when inherit-model is false', function () {
+                $scope.inheritModel = true;
+                $scope.inheritDateTime = '2015-04-27T11:29:05.474Z';
+                $scope.dt = '2015-05-10T09:15:02.474Z';
+                compileTemplate(
+                    '<rb-datetime-control name="test" ng-model="dt" inherit-datetime="{{inheritDateTime}}"' +
+                    ' is-required="true" inherit-model="inheritModel" form="aForm"></rb-datetime-control>'
+                );
+
+                expect($scope.dt).toBe('2015-04-27T11:29:05.474Z');
+
+                $scope.inheritModel = false;
+                $scope.$apply();
+                isolatedScope.toggleInherited();
+                isolatedScope.$apply();
+                $scope.$apply();
+
+                expect($scope.dt).toBe('2015-05-10T09:15:02.474Z');
+
+            });
         });
 
         describe('validation', function () {


### PR DESCRIPTION
`rb-datetime-control` should be preserving original state when toggling inheritance. This fix makes it usable in edit line item form.

Existing TP https://rockabox.tpondemand.com/entity/9562