### PR TITLE
Use `angular-scroll` for `rb-scrollspy`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 - [`rb-datetime-control` `inherit-datetime` attribute](https://github.com/rockabox/rbx_ui_components/pull/156). Supercedes `inherit` attribute.
 - [`rb-datetime-control` `inherit-model` optional property attribute](https://github.com/rockabox/rbx_ui_components/pull/156). Date inheritence should be treated as a model.
+- [`rb-scrollspy` `scroll-id` attribute](https://github.com/rockabox/rbx_ui_components/pull/183). For observing scroll changes on custom elements.
 
 ### Changed
 
@@ -19,6 +20,8 @@ For multiple checkboxes use `rb-check-control-group` instead of `rb-check-contro
 - [`rb-datetime` component renamed `rb-datetime-display`](https://github.com/rockabox/rbx_ui_components/pull/177)
 - [`rb-ratio` component renamed `rb-ratio-display`](https://github.com/rockabox/rbx_ui_components/pull/175)
 - [`rb-scrollspy` now builds top level list from `items` property not `sections`](https://github.com/rockabox/rbx_ui_components/pull/172)
+- [`rb-scrollspy` now animates](https://github.com/rockabox/rbx_ui_components/pull/183). As part of `angular-strap` integration.
+- [`rb-scrollspy` now uses `angular-scroll` instead of `angular-strap` scrollspy](https://github.com/rockabox/rbx_ui_components/pull/183). To enable observation of scroll positioning in custom elements such as modals.
 
 ### Removed
 

--- a/bower.json
+++ b/bower.json
@@ -34,6 +34,7 @@
   "dependencies": {
     "angular-aria": "~1.3.0",
     "angular-elastic": "rockabox/angular-elastic#master",
+    "angular-scroll": "~0.7.0",
     "angular-strap": "~2.2.1"
   }
 }

--- a/src/rb-scrollspy/demo/demo.tpl.html
+++ b/src/rb-scrollspy/demo/demo.tpl.html
@@ -1,12 +1,31 @@
+<style type="text/css">
+  #container {
+    overflow: scroll;
+    height: 500px;
+    position: absolute;
+    top: 50px;
+    left: 180px;
+  }
+
+  .search {
+      position:absolute;
+      left:180px;
+      top:0;
+      height:50px;
+  }
+</style>
+
 <div>
     <div style="position: fixed; top: 10px; left: 50px">
-        <rb-scrollspy categories="demoCtrl.filteredCategories" offset="10"></rb-scrollspy>
+        <rb-scrollspy categories="demoCtrl.filteredCategories" offset="0" scroll-id="container"></rb-scrollspy>
     </div>
 
-    <div style="position: absolute;top:0; left: 180px">
-        <div>
-            <input type="text" ng-model="search" placeholder="Search list...">
-            <hr />
+    <div class="search">
+        <input type="text" ng-model="search" placeholder="Search list...">
+        <hr />
+    </div>
+
+    <div id="container">
         <div>
             <span ng-repeat="category in demoCtrl.filteredCategories">
                 <h2 id="{{ category.anchor }}" class="ListyThing-Category">

--- a/src/rb-scrollspy/index.js
+++ b/src/rb-scrollspy/index.js
@@ -1,10 +1,8 @@
 define([
-    'angular-strap/dist/modules/debounce.js',
-    'angular-strap/dist/modules/dimensions.js',
-    'angular-strap/dist/modules/scrollspy.js',
+    'angular-scroll',
     './rb-scrollspy-directive',
     './rb-scrollspy.css'
-], function (bsDebounce, bsDimensions, bsscrollspy, rbScrollspyDirective, css) {
+], function (angularScroll, rbScrollspyDirective, css) {
     /**
      * @ngdoc module
      * @name rb-scrollspy
@@ -14,7 +12,7 @@ define([
      *
      */
     var rbScrollspy = angular
-        .module('rb-scrollspy', ['mgcrea.ngStrap.scrollspy'])
+        .module('rb-scrollspy', ['duScroll'])
         .directive('rbScrollspy', rbScrollspyDirective);
 
     return rbScrollspy;

--- a/src/rb-scrollspy/rb-scrollspy-directive.js
+++ b/src/rb-scrollspy/rb-scrollspy-directive.js
@@ -37,6 +37,7 @@ define([
      *          }
      *  'offset': Pixels to offset from top of screen when calculating position of
      *            scroll. Defaults to '0'.
+     *  'scroll-id': The element id to monitor for scroll changes.
      *
      * @usage
      * <hljs lang="html">
@@ -50,7 +51,8 @@ define([
         return {
             scope: {
                 categories: '=',
-                offset: '@'
+                offset: '@',
+                scrollId: '@'
             },
             restrict: 'E',
             replace: true,

--- a/src/rb-scrollspy/rb-scrollspy.tpl.html
+++ b/src/rb-scrollspy/rb-scrollspy.tpl.html
@@ -1,18 +1,24 @@
 <div>
-    <ul>
-        <li ng-repeat="category in categories track by $index">
+    <ul du-scroll-container="{{scrollId}}" du-spy-context>
+        <li ng-repeat="category in categories">
             <a class="Scrollspy-Category"
                href="#{{::category.anchor}}"
-               bs-scrollspy
-               data-target="#{{::category.anchor}}"
-               data-offset="{{::offset || 0}}"
-               ng-class="{'Scrollspy-Category--hidden': category.hidden}">
+               du-scrollspy
+               du-smooth-scroll
+               offset="{{offset || 0}}"
+               ng-class="{'Scrollspy-Category--hidden': category.hidden}"
+            >
                 <span>{{::category.label}}</span>
             </a>
 
             <ul>
-                <li ng-repeat="section in category.items track by $index">
-                    <a class="Scrollspy-Section" href="#{{::section.anchor}}" bs-scrollspy data-target="#{{::section.anchor}}" data-offset="{{::offset || 0}}">
+                <li ng-repeat="section in category.items">
+                    <a class="Scrollspy-Section"
+                        href="#{{::section.anchor}}"
+                        offset="{{offset || 0}}"
+                        du-scrollspy
+                        du-smooth-scroll
+                    >
                         <span>{{::section.label}}</span>
                     </a>
                 </li>

--- a/test/unit/rb-scrollspy/rb-scrollspy.spec.js
+++ b/test/unit/rb-scrollspy/rb-scrollspy.spec.js
@@ -120,7 +120,7 @@ define([
                 expect(angular.element(spans[4]).html()).toEqual('D');
             });
 
-            describe('anchors and bs-scrollspy attribute directive', function () {
+            describe('anchors and du-scrollspy attribute directive', function () {
 
                 it('should place an href attr per item with its anchor value', function () {
                     compileTemplate(template);
@@ -133,37 +133,34 @@ define([
                     expect(angular.element(anchors[4]).attr('href')).toEqual('#D');
                 });
 
-                it('should attach a bs-scrollspy attribute directive per item', function () {
+                it('should attach a du-scrollspy attribute directive per item', function () {
                     compileTemplate(template);
                     anchors = element.find('a');
 
-                    expect(anchors[0].hasAttribute('bs-scrollspy')).toBe(true);
-                    expect(anchors[1].hasAttribute('bs-scrollspy')).toBe(true);
-                    expect(anchors[2].hasAttribute('bs-scrollspy')).toBe(true);
-                    expect(anchors[3].hasAttribute('bs-scrollspy')).toBe(true);
-                    expect(anchors[4].hasAttribute('bs-scrollspy')).toBe(true);
+                    expect(anchors[0].hasAttribute('du-scrollspy')).toBe(true);
+                    expect(anchors[1].hasAttribute('du-scrollspy')).toBe(true);
+                    expect(anchors[2].hasAttribute('du-scrollspy')).toBe(true);
+                    expect(anchors[3].hasAttribute('du-scrollspy')).toBe(true);
+                    expect(anchors[4].hasAttribute('du-scrollspy')).toBe(true);
                 });
 
-                it('should place a bs-scrollspy `data-target` attribute per item', function () {
-                    compileTemplate(template);
-                    anchors = element.find('a');
-
-                    expect(angular.element(anchors[0]).attr('data-target')).toEqual('#countries');
-                    expect(angular.element(anchors[1]).attr('data-target')).toEqual('#A');
-                    expect(angular.element(anchors[2]).attr('data-target')).toEqual('#B');
-                    expect(angular.element(anchors[3]).attr('data-target')).toEqual('#C');
-                    expect(angular.element(anchors[4]).attr('data-target')).toEqual('#D');
-                });
-
-                it('should place a bs-scrollspy `data-offset` attribute when offset is present in scope', function () {
+                it('should place a du-scrollspy `offset` attribute when offset is present in scope', function () {
                     compileTemplate(templateWithOffset);
                     anchors = element.find('a');
 
-                    expect(angular.element(anchors[0]).attr('data-offset')).toEqual('100');
-                    expect(angular.element(anchors[1]).attr('data-offset')).toEqual('100');
-                    expect(angular.element(anchors[2]).attr('data-offset')).toEqual('100');
-                    expect(angular.element(anchors[3]).attr('data-offset')).toEqual('100');
-                    expect(angular.element(anchors[4]).attr('data-offset')).toEqual('100');
+                    expect(angular.element(anchors[0]).attr('offset')).toEqual('100');
+                    expect(angular.element(anchors[1]).attr('offset')).toEqual('100');
+                    expect(angular.element(anchors[2]).attr('offset')).toEqual('100');
+                    expect(angular.element(anchors[3]).attr('offset')).toEqual('100');
+                    expect(angular.element(anchors[4]).attr('offset')).toEqual('100');
+                });
+
+                it('should attach `du-scroll-container` to <a> elems with val of scroll-id attribute', function () {
+                    compileTemplate('<rb-scrollspy categories="categories" offset="100" scroll-id="test-id">' +
+                        '</rb-scrollspy>');
+                    list = angular.element(element.find('ul')[0]);
+
+                    expect(list.attr('du-scroll-container')).toEqual('test-id');
                 });
             });
 


### PR DESCRIPTION
The scrollspy provided by `angular-strap` did not allow for custom elements for scroll observation, and only allowed for observation on `window/document`, making it unusable in modals or overlays.

- Gutted out angular-strap and replaced with angular-scroll
- Pass in the `id` of the element to observe scrolling via `scroll-id` attr.
- Scroll-spy now animates. Sexy.
- Tests fixed
- Demos fixed

See `angular-scroll` here https://github.com/oblador/angular-scroll.

@ohskylab wasn't sure if I should put the base as `2.0.0` or `master` but feel free to edit it. I would like to see this in the next release!

TP https://rockabox.tpondemand.com/entity/9618