### PR TITLE
Fix `appearance` property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 - Nothing.
 
+### Fixed
+
+- [`appearance` property no longer requires manual prefixing](https://github.com/rockabox/rbx_ui_components/pull/187). Run `npm update` after updating to prevent breakage.
+
 ## [2.0.0] - 2015-05-02
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "grunt-env": "~0.4.4"
   },
   "dependencies": {
-    "autoprefixer-core": "~5.1.9",
+    "autoprefixer-core": "~5.2.0",
     "css-loader": "~0.10.1",
     "extract-text-webpack-plugin": "~0.5.0",
     "file-loader": "~0.8.1",

--- a/src/rb-select-control/rb-select-control.css
+++ b/src/rb-select-control/rb-select-control.css
@@ -25,7 +25,7 @@
 }
 
 /**
- * 1. Remove default appearance. Prefixed versions necessary, see: http://git.io/vTwoV
+ * 1. Remove default appearance.
  * 2. Set consistent spacing after every field.
  * 3. Remove `outline` in favour of `border`.
  * 4. Nudge `required` indicator from top right corner.
@@ -44,8 +44,6 @@
  */
 
 .SelectControl-field {
-    -moz-appearance: none;
-    -webkit-appearance: none;
     appearance: none; /* 1 */
     background: var(--SelectControl-field-background-color) url(var(--SelectControl-field-image)) no-repeat center right;
     border: 1px solid var(--SelectControl-field-border-color);
@@ -112,8 +110,6 @@
 
 .SelectControl-field:disabled,
 .SelectControl-field.is-disabled {
-    -moz-appearance: none;
-    -webkit-appearance: none;
     appearance: none;
     background: var(--SelectControl-field-disabled-background-color) url(var(--SelectControl-field-disabled-image)) no-repeat var(--SelectControl-field-disabled-image-position) !important; /* 5 */
     border: 1px solid var(--SelectControl-field-border-color) !important; /* 5 */


### PR DESCRIPTION
TP: https://rockabox.tpondemand.com/entity/9631

This may require matching `autoprefixer-core` bumps in projects that consume ui_components.

The `appearance` property has been accepted by CSS WG and is now supported by `autoprefixer-core`, so no longer requires manual prefixing. See: postcss/autoprefixer-core#14

There are some remaining `-webkit-appearance` and `-moz-appearance` properties in various components and base styles: these fix browser-specific issues and should remain as-is.