### PR TITLE
Checkbox group can use shared model.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
+- [`rb-check-control-group` can use shared model and watches external model changes](https://github.com/rockabox/rbx_ui_components/pull/191)
 - [`rb-definition-list` style and structure](https://github.com/rockabox/rbx_ui_components/pull/192)
 
 ### Fixed

--- a/src/rb-check-control/demo/demo-group-ctrl.js
+++ b/src/rb-check-control/demo/demo-group-ctrl.js
@@ -2,7 +2,7 @@ define([
 ], function () {
 
     // @ngInject
-    function demoGroupCtrl ($rootScope, $state, $injector) {
+    function demoGroupCtrl () {
 
         function getOptions () {
             return [
@@ -20,15 +20,38 @@ define([
                     value: 'required_label'
                 },
                 {
-                    checked: true,
                     label: 'Checked label',
                     value: 'checked_label'
                 }
             ];
         }
 
+        this.ngModelDefault = ['checked_label'];
+        this.ngModelSelectAll = ['checked_label'];
+        this.ngModelShared = ['checked_label', 'checked_label2'];
+
         this.defaultOptions = getOptions();
         this.selectAllOptions = getOptions();
+        this.sharedOptions = getOptions();
+        this.moreOptions = [
+            {
+                label: 'Default label 2',
+                value: 'default_label2'
+            },
+            {
+                label: 'Invalid label2',
+                value: 'invalid_label2'
+            },
+            {
+                label: 'Required label2',
+                required: true,
+                value: 'required_label2'
+            },
+            {
+                label: 'Checked label2',
+                value: 'checked_label2'
+            }
+        ];
     }
 
     return demoGroupCtrl;

--- a/src/rb-check-control/demo/demo-group.tpl.html
+++ b/src/rb-check-control/demo/demo-group.tpl.html
@@ -12,11 +12,32 @@
             <rb-check-control-group
                 form="checkControlForm"
                 name="check-control-default"
-                ng-model="ngModelDefault"
+                ng-model="demoCtrl.ngModelDefault"
                 options="demoCtrl.defaultOptions"
                 title="Basic Usage">
             </rb-check-control-group>
-            <pre>{{ ngModelDefault }}</pre>
+            <pre>{{ demoCtrl.ngModelDefault }}</pre>
+        </form>
+    </div>
+    <div class="ComponentView">
+        <form name="checkControlForm">
+            <rb-check-control-group
+                form="checkControlForm"
+                name="check-control-shared-one"
+                ng-model="demoCtrl.ngModelShared"
+                options="demoCtrl.sharedOptions"
+                title="Shared model">
+            </rb-check-control-group>
+
+            <rb-check-control-group
+                enable-select-all=true
+                form="checkControlForm"
+                name="check-control-shared-two"
+                ng-model="demoCtrl.ngModelShared"
+                options="demoCtrl.moreOptions"
+                title="Shared model with select all">
+            </rb-check-control-group>
+            <pre>{{ demoCtrl.ngModelShared }}</pre>
         </form>
     </div>
     <div class="ComponentView">
@@ -25,11 +46,11 @@
                 enable-select-all=true
                 form="checkControlSelectAllForm"
                 name="check-control-select-all"
-                ng-model="ngModelSelectAll"
+                ng-model="demoCtrl.ngModelSelectAll"
                 options="demoCtrl.selectAllOptions"
                 title="Select All">
             </rb-check-control-group>
-            <pre>{{ ngModelSelectAll }}</pre>
+            <pre>{{ demoCtrl.ngModelSelectAll }}</pre>
         </form>
     </div>
 </section>

--- a/src/rb-check-control/rb-check-control-group-directive.js
+++ b/src/rb-check-control/rb-check-control-group-directive.js
@@ -1,6 +1,7 @@
 define([
-    'html!./rb-check-control-group.tpl.html'
-], function (template) {
+    'html!./rb-check-control-group.tpl.html',
+    './rb-check-control-group-link'
+], function (template, linkFunc) {
 
     /**
      * @ngdoc directive
@@ -47,15 +48,7 @@ define([
             restrict: 'E',
             replace: true,
             template: template,
-            link: function ($scope, $element, $attributes) {
-
-                $scope.$watch('options|filter:{checked:true}', function (newOptions) {
-                    $scope.ngModel = newOptions.map(function (option) {
-                        return option.value;
-                    });
-                }, true);
-
-            }
+            link: linkFunc
         };
     }
 

--- a/src/rb-check-control/rb-check-control-group-link.js
+++ b/src/rb-check-control/rb-check-control-group-link.js
@@ -1,0 +1,66 @@
+define([],
+    function () {
+
+        /**
+         * rbCheckControlGroup Link function.
+         * Provides given model with strings of values checked.
+         * Sets checked fields based on given model.
+         */
+        function rbCheckControlGroupLink ($scope, $element, $attributes) {
+
+            // Check checkboxes who's value is in the model array
+            function setChecked () {
+                if ($scope.ngModel) {
+                    angular.forEach($scope.options, function (option) {
+                        if ($scope.ngModel.indexOf(option.value) > -1) {
+                            option.checked = true;
+                        }
+                    });
+                }
+            }
+
+            // Initial check when rendering
+            setChecked();
+
+            // If the model changes externally make sure we update the checkboxes
+            $scope.$watch('ngModel', function (newModel, oldModel) {
+
+                if (newModel === oldModel) {
+                    return;
+                }
+                setChecked();
+
+            }, true);
+
+            // When the checkboxes change update the model.
+            // Don't destory/override the model as it could be shared with another group.
+            $scope.$watch('options|filter:{checked:true}', function (newOptions, oldOptions) {
+
+                if (newOptions === oldOptions) {
+                    return;
+                }
+
+                if (!$scope.ngModel) {
+                    $scope.ngModel = [];
+                }
+
+                // Remove all previously selected from model
+                angular.forEach(oldOptions, function (option) {
+                    var index = $scope.ngModel.indexOf(option.value);
+                    if (index > -1) {
+                        $scope.ngModel.splice(index, 1);
+                    }
+                });
+
+                // Add all currently selected to model
+                newOptions.map(function (option) {
+                    if ($scope.ngModel.indexOf(option.value) < 0) {
+                        $scope.ngModel.push(option.value);
+                    }
+                });
+
+            }, true);
+        }
+
+        return rbCheckControlGroupLink;
+    });

--- a/src/rb-check-control/rb-check-control-group.tpl.html
+++ b/src/rb-check-control/rb-check-control-group.tpl.html
@@ -10,7 +10,7 @@
 
     <label ng-if="!enableSelectAll && title">{{::title}}</label>
 
-    <div ng-repeat="(key, value) in ::options">
+    <div ng-repeat="(key, value) in options">
         <rb-check-control
             is-disabled="{{::isDisabled}}"
             is-required="{{::isRequired}}"

--- a/test/unit/rb-check-control/rb-check-control-group.spec.js
+++ b/test/unit/rb-check-control/rb-check-control-group.spec.js
@@ -11,22 +11,18 @@ define([
             isolatedScope,
             options = [
                 {
-                    checked: false,
                     label: 'One',
                     value: 'one'
                 },
                 {
-                    checked: true,
                     label: 'Two',
                     value: 'two'
                 },
                 {
-                    checked: true,
                     label: 'Three',
                     value: 'three'
                 }
-            ],
-            ngModel = [];
+            ];
 
         beforeEach(angular.mock.module(
             rbCheckControl.name
@@ -38,21 +34,17 @@ define([
             $scope = _$rootScope_.$new({});
 
             compileTemplate = function (template) {
-                $scope.options = options;
-                $scope.ngModel = ngModel;
                 element = $compile(template)($scope);
                 $scope.$apply();
                 isolatedScope = element.isolateScope();
             };
         }));
 
-        describe('checkedOptions', function () {
-            beforeEach(function () {
-                compileTemplate('<rb-check-control-group options="options" ng-model="ngModel">' +
-                    '</rb-check-control-group>');
-            });
-
+        describe('option', function () {
             it('should render three inputs with correct values', function () {
+                $scope.options = options;
+                compileTemplate('<rb-check-control-group options="options" ng-model="model"></rb-check-control-group>');
+
                 var inputs = element.find('input');
 
                 expect(inputs.length).toBe(3);
@@ -62,20 +54,149 @@ define([
             });
 
             it('should render three labels with correct values', function () {
+                $scope.options = options;
+                compileTemplate('<rb-check-control-group options="options" ng-model="model"></rb-check-control-group>');
+
                 var labels = element.find('label');
 
                 expect(labels.eq(0).html()).toContain('One');
                 expect(labels.eq(1).html()).toContain('Two');
                 expect(labels.eq(2).html()).toContain('Three');
             });
+        });
 
-            it('should return an array with two items', function () {
-                expect($scope.ngModel.length).toBe(2);
+        describe('model binding', function () {
+
+            it('should check any values in ngModel', function () {
+                // Before render
+                $scope.options = options;
+                $scope.ngModel = ['two'];
+                compileTemplate(
+                    '<rb-check-control-group options="options" ng-model="ngModel"></rb-check-control-group>'
+                );
+
+                var inputs = element.find('input');
+                expect(inputs.eq(1).attr('checked')).toBe('checked');
             });
 
-            it('should contain string values', function () {
-                expect($scope.ngModel[0]).toBe('two');
-                expect($scope.ngModel[1]).toBe('three');
+            it('should update checked when ngModel changes', function () {
+                $scope.options = options;
+                $scope.ngModel = [];
+                compileTemplate(
+                    '<rb-check-control-group options="options" ng-model="ngModel"></rb-check-control-group>'
+                );
+
+                //After render
+                $scope.ngModel.push('one');
+                $scope.$apply();
+
+                var inputs = element.find('input');
+                expect(inputs.eq(0).attr('checked')).toBe('checked');
+            });
+
+            it('should only have one instance of a value in the model', function () {
+                // Before render
+                $scope.ngModel = [];
+                $scope.options = [
+                    {
+                        label: 'One',
+                        value: 'one'
+                    },
+                    {
+                        label: 'One One',
+                        value: 'one'
+                    },
+                    {
+                        label: 'Two',
+                        value: 'two'
+                    }
+                ];
+                compileTemplate(
+                    '<rb-check-control-group options="options" ng-model="ngModel"></rb-check-control-group>'
+                );
+
+                isolatedScope.options[0].checked = true;
+                isolatedScope.options[1].checked = true;
+                $scope.$apply();
+
+                expect($scope.ngModel).toEqual(['one']);
+            });
+        });
+
+        describe('checkbox state', function () {
+
+            it('should update model when state changes', function () {
+                // Before render
+                $scope.ngModel = [];
+                $scope.options = [
+                    {
+                        label: 'One',
+                        value: 'one'
+                    },
+                    {
+                        label: 'Two',
+                        value: 'two'
+                    }
+                ];
+                compileTemplate(
+                    '<rb-check-control-group options="options" ng-model="ngModel"></rb-check-control-group>'
+                );
+
+                isolatedScope.options[0].checked = true;
+                $scope.$apply();
+
+                expect($scope.ngModel).toEqual(['one']);
+            });
+
+            it('should update model when state changes and preseve model from other groups', function () {
+                // Before render
+                $scope.ngModel = ['three'];
+                $scope.options = [
+                    {
+                        label: 'One',
+                        value: 'one'
+                    },
+                    {
+                        label: 'Two',
+                        value: 'two'
+                    }
+                ];
+                compileTemplate(
+                    '<rb-check-control-group options="options" ng-model="ngModel"></rb-check-control-group>'
+                );
+
+                isolatedScope.options[0].checked = true;
+                $scope.$apply();
+
+                expect($scope.ngModel).toEqual(['three', 'one']);
+            });
+
+            it('should update model and not remove values from other checkbox groups', function () {
+                // Before render
+                $scope.ngModel = ['test'];
+                $scope.options = [
+                    {
+                        label: 'One',
+                        value: 'one'
+                    },
+                    {
+                        label: 'Two',
+                        value: 'two'
+                    }
+                ];
+                compileTemplate(
+                    '<rb-check-control-group options="options" ng-model="ngModel"></rb-check-control-group>'
+                );
+
+                // Simulate model changing externally and removing something that was checked before.
+                isolatedScope.options[0].checked = true;
+                $scope.$apply();
+                $scope.ngModel = ['test'];
+                isolatedScope.options[0].checked = false;
+                isolatedScope.options[1].checked = true;
+                $scope.$apply();
+
+                expect($scope.ngModel).toEqual(['test', 'two']);
             });
         });
     });


### PR DESCRIPTION
TP: https://rockabox.tpondemand.com/entity/9647

- Checkbox Group can share a model non-destructively with another checkbox group.
- Checkbox Group can set checked checkboxes from model on render and if model changes externally.