### PR TITLE
Style `rb-definition-list` component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 - [`rb-generic-form` `-buttons` descendent](https://github.com/rockabox/rbx_ui_components/pull/186)
 
+### Changed
+
+- [`rb-definition-list` style and structure](https://github.com/rockabox/rbx_ui_components/pull/192)
+
 ### Fixed
 
 - [`appearance` property no longer requires manual prefixing](https://github.com/rockabox/rbx_ui_components/pull/187). Run `npm update` after updating to prevent breakage.

--- a/src/rb-definition-list/demo/demo-ctrl.js
+++ b/src/rb-definition-list/demo/demo-ctrl.js
@@ -3,6 +3,10 @@ define([
 
     // @ngInject
     function demoCtrl ($rootScope, $state, $injector) {
+
+        this.onButtonClick = function () {
+            console.log('Edit Targeting Button Clicked');
+        };
     }
 
     return demoCtrl;

--- a/src/rb-definition-list/demo/demo.tpl.html
+++ b/src/rb-definition-list/demo/demo.tpl.html
@@ -8,7 +8,7 @@
         </p>
     </div>
     <div class="ComponentView">
-        <rb-definition-list>
+        <rb-definition-list button-text="Edit targeting" button-click="demoCtrl.onButtonClick()">
             <rb-definition-list-item icon="black-16-frequency" label="Frequency Cap">
                 <span>No targeting</span>
             </rb-definition-list-item>

--- a/src/rb-definition-list/demo/demo.tpl.html
+++ b/src/rb-definition-list/demo/demo.tpl.html
@@ -1,15 +1,31 @@
-<rb-definition-list>
-    <rb-definition-list-item icon="black-16-geo" label="Geo">
-        <span>France, Germany, United Kingdom</span>
-    </rb-definition-list-item>
-    <rb-definition-list-item icon="black-16-segmentation" label="Segmentation">
-        <b>Exclude:</b> List of categories to exclude
-        <b>Include:</b> List of categories to include
-    </rb-definition-list-item>
-    <rb-definition-list-item icon="black-16-categories" label="Categories">
-        <span>Arts &amp; Entertainment (16/16), Education (2/8)</span>
-    </rb-definition-list-item>
-    <rb-definition-list-item label="Iconless title">
-        <span>no icon</span>
-    </rb-definition-list-item>
-</rb-definition-list>
+<section class="Section">
+    <div class="RawHTML">
+        <h2>
+            rb-definition-list
+        </h2>
+        <p>
+            The <code>rb-definition-list</code> component should be used for displaying name-value structures.
+        </p>
+    </div>
+    <div class="ComponentView">
+        <rb-definition-list>
+            <rb-definition-list-item icon="black-16-frequency" label="Frequency Cap">
+                <span>No targeting</span>
+            </rb-definition-list-item>
+            <rb-definition-list-item icon="black-16-geo" label="Geo">
+                <span>France, Germany, United Kingdom</span>
+            </rb-definition-list-item>
+            <rb-definition-list-item icon="black-16-segmentation" label="Segmentation">
+                <p>
+                    <strong>Exclude:</strong> List of categories to exclude
+                </p>
+                <p>
+                    <strong>Include:</strong> List of categories to include
+                </p>
+            </rb-definition-list-item>
+            <rb-definition-list-item icon="black-16-categories" label="Categories">
+                <span>Arts &amp; Entertainment (16/16), Education (2/8)</span>
+            </rb-definition-list-item>
+        </rb-definition-list>
+    </div>
+</section>

--- a/src/rb-definition-list/index.js
+++ b/src/rb-definition-list/index.js
@@ -1,8 +1,10 @@
 define([
+    'components/rb-button',
+    'components/rb-icon',
     './rb-definition-list-directive',
     './rb-definition-list-item-directive',
     './rb-definition-list.css'
-], function (rbDefinitionListDirective, rbDefinitionListItemDirective, css) {
+], function (rbButton, rbIcon, rbDefinitionListDirective, rbDefinitionListItemDirective, css) {
     /**
      * @ngdoc module
      * @name rb-definition-list
@@ -12,7 +14,7 @@ define([
      *
      */
     var rbDefinitionList = angular
-        .module('rb-definition-list', [])
+        .module('rb-definition-list', [rbButton.name, rbIcon.name])
         .directive('rbDefinitionList', rbDefinitionListDirective)
         .directive('rbDefinitionListItem', rbDefinitionListItemDirective);
 

--- a/src/rb-definition-list/rb-definition-list-directive.js
+++ b/src/rb-definition-list/rb-definition-list-directive.js
@@ -23,6 +23,10 @@ define([
     function rbDefinitionListDirective () {
 
         return {
+            scope: {
+                buttonText: '@',
+                buttonClick: '&'
+            },
             restrict: 'E',
             replace: true,
             transclude: true,

--- a/src/rb-definition-list/rb-definition-list-item-directive.js
+++ b/src/rb-definition-list/rb-definition-list-item-directive.js
@@ -33,6 +33,7 @@ define([
                 'icon': '@',
                 'label': '@'
             },
+            replace: true,
             restrict: 'E',
             transclude: true,
             template: template

--- a/src/rb-definition-list/rb-definition-list-item.tpl.html
+++ b/src/rb-definition-list/rb-definition-list-item.tpl.html
@@ -1,2 +1,10 @@
-<dt><rb-icon ng-if="icon" icon="{{icon}}">{{label}}</rb-icon>{{label}}</dt>
-<dd ng-transclude></dd>
+<li class="DefinitionList-item">
+    <div class="DefinitionList-title">
+        <div class="DefinitionList-icon">
+            <rb-icon ng-if="icon" icon="{{icon}}">{{label}}</rb-icon>
+        </div>
+        <h3>{{label}}</h3>
+    </div>
+    <div class="DefinitionList-body u-textSmall" ng-transclude>
+    </div>
+</li>

--- a/src/rb-definition-list/rb-definition-list.css
+++ b/src/rb-definition-list/rb-definition-list.css
@@ -14,20 +14,3 @@
 
 .rbDefinitionList {
 }
-
-dl.multicolumn {
-    overflow: auto;
-}
-dl.multicolumn dt, dl.multicolumn dd {
-    float: left;
-}
-dl.multicolumn dt {
-    clear: left;
-    width: 13%;
-    margin-right: 2%;
-    font-weight: bold;
-}
-dl.multicolumn dd {
-    width: 85%;
-    margin-left: 0;
-}

--- a/src/rb-definition-list/rb-definition-list.css
+++ b/src/rb-definition-list/rb-definition-list.css
@@ -1,16 +1,64 @@
-/** @define rbDefinitionList; use strict */
+/** @define DefinitionList; use strict */
 
 /**
- * The `.rbDefinitionList` component...
+ * The `.DefinitionList` component should be used for displaying name-value structures.
  */
 
 :root {
-    --rbDefinitionList-variable: var();
+    --DefinitionList-border: var(--color-gray-ghost);
 }
 
 /**
- * 1. Comment
+ * 1. Linearize layout for small viewport
+ * 2. Stripe odd items
  */
 
-.rbDefinitionList {
+.DefinitionList-toolbar {
+    margin-bottom: 1.5em;
+}
+
+.DefinitionList-main {
+    border-top: 1px solid var(--DefinitionList-border);
+    width: 100%;
+}
+
+.DefinitionList-item {
+    background: var(--color-white-alabaster);
+    display: flex;
+    flex-direction: column; /* 1 */
+    padding: 1.5em 0;
+}
+
+@media (--md-viewport) {
+
+    .DefinitionList-item {
+        flex-direction: row;  /* 1 */
+    }
+
+}
+
+.DefinitionList-item:nth-child(odd) {
+    background: var(--color-white-catskill); /* 2 */
+}
+
+.DefinitionList-title {
+    display: flex;
+    padding: 0 2em;
+    width: 14em;
+}
+
+.DefinitionList-icon {
+    margin-right: 1em;
+}
+
+.DefinitionList-body {
+    padding: 0 2em;
+}
+
+@media (--md-viewport) {
+
+    .DefinitionList-body {
+        border-left: 1px solid var(--DefinitionList-border);
+    }
+
 }

--- a/src/rb-definition-list/rb-definition-list.tpl.html
+++ b/src/rb-definition-list/rb-definition-list.tpl.html
@@ -1,7 +1,7 @@
 <div class="DefinitionList">
     <div class="DefinitionList-toolbar">
         <div class="DataActionTable-action">
-            <rb-button>Edit Targeting</rb-button>
+            <rb-button ng-if="buttonText" ng-click="buttonClick()">{{ ::buttonText }}</rb-button>
         </div>
     </div>
     <ul class="DefinitionList-main" ng-transclude></ul>

--- a/src/rb-definition-list/rb-definition-list.tpl.html
+++ b/src/rb-definition-list/rb-definition-list.tpl.html
@@ -1,2 +1,8 @@
-<dl class="multicolumn" ng-transclude>
-</dl>
+<div class="DefinitionList">
+    <div class="DefinitionList-toolbar">
+        <div class="DataActionTable-action">
+            <rb-button>Edit Targeting</rb-button>
+        </div>
+    </div>
+    <ul class="DefinitionList-main" ng-transclude></ul>
+</div>

--- a/test/unit/rb-definition-list/rb-definition-list-item.spec.js
+++ b/test/unit/rb-definition-list/rb-definition-list-item.spec.js
@@ -27,37 +27,42 @@ define([
 
         describe('rendering', function () {
 
-            it('should render with a "rb-definition-list-item" tagname', function () {
+            it('should render with a "li" tagname', function () {
                 compileTemplate('<rb-definition-list-item></rb-definition-list-item>');
 
-                expect(element[0].tagName.toLowerCase()).toEqual('rb-definition-list-item');
+                expect(element[0].tagName.toLowerCase()).toEqual('li');
             });
 
-            it('should attach an icon to the dt when present', function () {
+            it('should attach an icon to the li when present', function () {
                 compileTemplate('<rb-definition-list-item icon="any-icon"></rb-definition-list-item>');
 
-                expect(element.find('dt').html()).toContain('icon="any-icon"');
+                var icons = element[0].getElementsByClassName('Icon'),
+                    icon = angular.element(icons[0]);
+
+                expect(icons.length).toBe(1);
+                expect(icon.hasClass('Icon--any-icon')).toBe(true);
             });
 
             it('should not attach an icon to the dt when not present', function () {
                 compileTemplate('<rb-definition-list-item></rb-definition-list-item>');
 
-                expect(element.find('dt').html()).not.toContain('rb-icon');
+                expect(element.find('icon').length).toBe(0);
             });
 
             it('should display a label for the dt', function () {
                 compileTemplate('<rb-definition-list-item label="any-label"></rb-definition-list-item>');
 
-                expect(element.find('dt').html()).toContain('any-label');
+                expect(element.find('h3').text()).toContain('any-label');
             });
 
             it('should render transcluded elements into the details', function () {
                 compileTemplate('<rb-definition-list-item><span>Transcluded detail</span></rb-definition-list-item>');
 
-                expect(element.find('dd').html()).toContain('Transcluded detail');
+                var body = angular.element(element[0].getElementsByClassName('DefinitionList-body')[0]);
+
+                expect(body.html()).toContain('Transcluded detail');
             });
 
         });
-
     });
 });

--- a/test/unit/rb-definition-list/rb-definition-list.spec.js
+++ b/test/unit/rb-definition-list/rb-definition-list.spec.js
@@ -27,10 +27,16 @@ define([
 
         describe('rendering', function () {
 
-            it('should render with a "dl" tagname', function () {
+            it('should render with a "div" tagname', function () {
                 compileTemplate('<rb-definition-list></rb-definition-list>');
 
-                expect(element[0].tagName.toLowerCase()).toEqual('dl');
+                expect(element[0].tagName.toLowerCase()).toEqual('div');
+            });
+
+            it('should render with a "ul" tag', function () {
+                compileTemplate('<rb-definition-list></rb-definition-list>');
+
+                expect(element.find('ul').length).toBe(1);
             });
 
             it('should render transcluded elements', function () {
@@ -42,5 +48,34 @@ define([
 
         });
 
+        describe('button', function () {
+
+            it('should take button-text from attribute', function () {
+                compileTemplate('<rb-definition-list button-text="Action"></rb-definition-list>');
+
+                var buttons = element.find('button'),
+                    button = angular.element(element.find('button')[0]);
+
+                expect(buttons.length).toBe(1);
+                expect(button.text()).toContain('Action');
+            });
+
+            it('should not render button if button-text is missing', function () {
+                compileTemplate('<rb-definition-list></rb-definition-list>');
+
+                expect(element.find('button').length).toBe(0);
+            });
+
+            it('should set button ng-click to button-click', function () {
+                $scope.onButtonClick = function () {};
+                spyOn($scope, 'onButtonClick');
+                compileTemplate(
+                    '<rb-definition-list button-text="Test" button-click="onButtonClick()"></rb-definition-list>'
+                );
+
+                isolatedScope.buttonClick();
+                expect($scope.onButtonClick).toHaveBeenCalled();
+            });
+        });
     });
 });


### PR DESCRIPTION
TP: https://rockabox.tpondemand.com/entity/9376

* Use an unordered list with headings, rather than definition list. Using a definition list element confers no benefits and reduces flexibility.
* Add (optional) toolbar descendant, with (optional) button descendant: mirrors `rb-table` structure.