### PR TITLE
Fix definition list layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased][unreleased]
 
-### Added
+### Fixed
 
-Nothing.
+- [`rb-definition-list` layout bug](https://github.com/rockabox/rbx_ui_components/pull/200)
 
 ## [2.1.0] - 2015-06-05
 

--- a/src/rb-definition-list/rb-definition-list.css
+++ b/src/rb-definition-list/rb-definition-list.css
@@ -43,8 +43,8 @@
 
 .DefinitionList-title {
     display: flex;
+    min-width: 14em;
     padding: 0 2em;
-    width: 14em;
 }
 
 .DefinitionList-icon {


### PR DESCRIPTION
Long text in the body part was pushing container into title part. Setting `min-width` prevents collapse.