### PR TITLE
Modify `rb-page-title` class structure to support other components

### DIFF
--- a/src/rb-page-title/demo/demo.tpl.html
+++ b/src/rb-page-title/demo/demo.tpl.html
@@ -11,7 +11,7 @@
             <li>A mandatory page body, containing a mandatory page heading.</li>
             <li>An optional badge, displayed near the page heading.</li>
             <li>An optional subheading.</li>
-            <li>An optional action, containing a button or a set of buttons to fire it.</li>
+            <li>An optional action descendent.</li>
         </ul>
         <h3>
             Demo

--- a/src/rb-page-title/rb-page-title.css
+++ b/src/rb-page-title/rb-page-title.css
@@ -52,7 +52,7 @@
     font-size: var(--font-size-small);
 }
 
-.PageTitle-button {
+.PageTitle-action {
     flex: none;
     margin: auto 0 auto auto; /* 3 */
     padding-left: 1em;

--- a/src/rb-page-title/rb-page-title.tpl.html
+++ b/src/rb-page-title/rb-page-title.tpl.html
@@ -17,6 +17,6 @@
             {{ subheading }}
         </p>
     </div>
-    <div class="PageTitle-button" ng-transclude>
+    <div class="PageTitle-action" ng-transclude>
     </div>
 </div>


### PR DESCRIPTION
TP: https://rockabox.tpondemand.com/entity/9782

Just a simple naming convention fix. Requires someone to merge into story branch and pick up the corresponding Angular part.

Here's some sample mark-up (basically a static version of the directive's template) showing `rb-page-title` with a search-type `rb-text-control`.

```html
<div class="PageTitle">
    <div class="PageTitle-inner">
        <div class="PageTitle-navigation" ng-if="backText && backSref">
            <a class="u-linkClean" ui-sref="{{ backSref }}">← {{ backText }}</a>
        </div>
        <div class="PageTitle-body">
            <div class="PageTitle-heading">
                <h1 class="u-textHeading1">
                    {{ heading }}
                </h1>
            </div>
            <div class="PageTitle-badge" ng-if="badgeStatus">
                <rb-badge state="{{ badgeStatus }}" collapsed="false"></rb-badge>
            </div>
        </div>
        <p class="PageTitle-sub" ng-if="subheading">
            {{ subheading }}
        </p>
    </div>
    <div class="PageTitle-action" ng-transclude>
    </div>
</div>
```