### PR TITLE
Add `size` attribute to `rb-grid-cell` component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - [`rb-nav-bar` sets `is-active` based on state](https://github.com/rockabox/rbx_ui_components/pull/210) Add is-active class when the related ui-sref directive's state is active and remove when it is inactive.
 - [`rb-check-with-text-control`](https://github.com/rockabox/rbx_ui_components/pull/209)
 - [`rb-check-with-text-control-group`](https://github.com/rockabox/rbx_ui_components/pull/212)
+- [`rb-grid-cell` `size` attribute for cell sizing](https://github.com/rockabox/rbx_ui_components/pull/222)
 
 ### Changed
 

--- a/src/rb-grid/demo/demo.tpl.html
+++ b/src/rb-grid/demo/demo.tpl.html
@@ -79,13 +79,20 @@
             Individual Sizing
         </h3>
         <p>
-             Add sizing classes to individual cells for specific widths. Cells without sizing classes divide up the
-             remaining space.
+            Add the <code>size</code> attribute to individual cells for specific widths. Cells without sizing classes divide up the
+            remaining space. The available sizes are:
+            <ul>
+             <li>1of2</li>
+             <li>1of3</li>
+             <li>2of3</li>
+             <li>1of4</li>
+             <li>3of4</li>
+            </ul>
         </p>
     </div>
     <div class="ComponentView">
         <rb-grid>
-            <rb-grid-cell class="u-size1of2">
+            <rb-grid-cell size="1of2">
                 <rb-demo-block>
                     1 of 2
                 </rb-demo-block>
@@ -97,7 +104,7 @@
             </rb-grid-cell>
         </rb-grid>
         <rb-grid>
-            <rb-grid-cell class="u-size1of3">
+            <rb-grid-cell size="1of3">
                 <rb-demo-block>
                     1 of 3
                 </rb-demo-block>
@@ -109,7 +116,7 @@
             </rb-grid-cell>
         </rb-grid>
         <rb-grid>
-            <rb-grid-cell class="u-size2of3">
+            <rb-grid-cell size="2of3">
                 <rb-demo-block>
                     2 of 3
                 </rb-demo-block>
@@ -121,7 +128,7 @@
             </rb-grid-cell>
         </rb-grid>
         <rb-grid>
-            <rb-grid-cell class="u-size1of4">
+            <rb-grid-cell size="1of4">
                 <rb-demo-block>
                     1 of 4
                 </rb-demo-block>
@@ -133,7 +140,7 @@
             </rb-grid-cell>
         </rb-grid>
         <rb-grid>
-            <rb-grid-cell class="u-size3of4">
+            <rb-grid-cell size="3of4">
                 <rb-demo-block>
                     3 of 4
                 </rb-demo-block>

--- a/src/rb-grid/rb-grid-cell-directive.js
+++ b/src/rb-grid/rb-grid-cell-directive.js
@@ -23,6 +23,7 @@ define([
 
         return {
             scope: {
+                size: '@'
             },
             restrict: 'E',
             replace: true,

--- a/src/rb-grid/rb-grid-cell.tpl.html
+++ b/src/rb-grid/rb-grid-cell.tpl.html
@@ -1,1 +1,7 @@
-<div class="Grid-cell" ng-transclude></div>
+<div class="Grid-cell" ng-transclude ng-class="{
+    'u-size1of2': size==='1of2',
+    'u-size1of3': size==='1of3',
+    'u-size2of3': size==='2of3',
+    'u-size1of4': size==='1of4',
+    'u-size3of4': size==='3of4'
+}"></div>

--- a/test/unit/rb-grid/rb-grid-cell.spec.js
+++ b/test/unit/rb-grid/rb-grid-cell.spec.js
@@ -25,6 +25,13 @@ define([
             };
         }));
 
+        describe('isolated scope', function () {
+            it('should accept the expected attributes', function () {
+                compileTemplate('<rb-grid-cell size="1of2"></rb-grid-cell>');
+                expect(isolatedScope.size).toEqual('1of2');
+            });
+        });
+
         describe('compiled template', function () {
             it('should render with the expected SUIT class', function () {
                 compileTemplate('<rb-grid-cell></rb-grid-cell>');
@@ -35,6 +42,39 @@ define([
                 compileTemplate('<rb-grid-cell>TEST</rb-grid-cell>');
                 expect(element.text()).toBe('TEST');
             });
+
+            describe('size `attr`', function () {
+                it('should set the correct helper class for size=`1of2`', function () {
+                    compileTemplate('<rb-grid-cell size="1of2"></rb-grid-cell>');
+                    expect(element.hasClass('u-size1of2')).toBe(true);
+                });
+
+                it('should set the correct helper class for size=`1of3`', function () {
+                    compileTemplate('<rb-grid-cell size="1of3"></rb-grid-cell>');
+                    expect(element.hasClass('u-size1of3')).toBe(true);
+                });
+
+                it('should set the correct helper class for size=`2of3`', function () {
+                    compileTemplate('<rb-grid-cell size="2of3"></rb-grid-cell>');
+                    expect(element.hasClass('u-size2of3')).toBe(true);
+                });
+
+                it('should set the correct helper class for size=`1of4`', function () {
+                    compileTemplate('<rb-grid-cell size="1of4"></rb-grid-cell>');
+                    expect(element.hasClass('u-size1of4')).toBe(true);
+                });
+
+                it('should set the correct helper class for size=`3of4`', function () {
+                    compileTemplate('<rb-grid-cell size="3of4"></rb-grid-cell>');
+                    expect(element.hasClass('u-size3of4')).toBe(true);
+                });
+
+                it('should not set a helper class for other input', function () {
+                    compileTemplate('<rb-grid-cell size="6of7"></rb-grid-cell>');
+                    expect(element.hasClass('u-size6of7')).not.toBe(true);
+                });
+            });
+
         });
 
     });

--- a/test/unit/rb-grid/rb-grid-cell.spec.js
+++ b/test/unit/rb-grid/rb-grid-cell.spec.js
@@ -25,11 +25,14 @@ define([
             };
         }));
 
-        describe('rendering', function () {
-            it('should render with class and transclude', function () {
-                compileTemplate('<rb-grid-cell>TEST</rb-grid-cell>');
-
+        describe('compiled template', function () {
+            it('should render with the expected SUIT class', function () {
+                compileTemplate('<rb-grid-cell></rb-grid-cell>');
                 expect(element.hasClass('Grid-cell')).toBe(true);
+            });
+
+            it('should transclude content', function () {
+                compileTemplate('<rb-grid-cell>TEST</rb-grid-cell>');
                 expect(element.text()).toBe('TEST');
             });
         });


### PR DESCRIPTION
Only allows for predefined sizes for which there are helper classes, i.e.
- 1of2
- 1of3
- 2of3
- 1of4
- 3of4

TP https://rockabox.tpondemand.com/entity/9708