### PR TITLE
Hide default text selection style in check and radio componets

### DIFF
--- a/src/rb-check-control/rb-check-control.css
+++ b/src/rb-check-control/rb-check-control.css
@@ -1,16 +1,13 @@
-/** @define rbCheckControl; use strict */
+/** @define CheckControl; use strict */
 
 /**
- * The `.rbCheckControl` component...
+ * The `.CheckControl` component...
  */
-
-:root {
-    --rbCheckControl-variable: var();
-}
 
 /**
- * 1. Comment
+ * 1. Hide default text selection style.
  */
 
-.rbCheckControl {
+.CheckControl::selection {
+    background: none; /* 1 */
 }

--- a/src/rb-radio-control/rb-radio-control.css
+++ b/src/rb-radio-control/rb-radio-control.css
@@ -9,10 +9,11 @@
 }
 
 /**
- * 1. Comment
+ * 1. Hide default text selection style.
  */
 
-.RadioControl {
+.RadioControl::selection {
+    background: none; /* 1 */
 }
 
 .RadioControl--row .RadioControl-items {


### PR DESCRIPTION
Stops weird text highlighting in composite controls.