### PR TITLE
Fix grid demo

### DIFF
--- a/src/rb-grid/demo/demo.tpl.html
+++ b/src/rb-grid/demo/demo.tpl.html
@@ -80,8 +80,12 @@
         <rb-section title="Individual Sizing">
             <div class="RawHTML">
                 <p>
-                    Add the <code>size</code> attribute to individual cells for specific widths. Cells without sizing classes divide up the
-                    remaining space. The available sizes are:
+                    Add the <code>size</code> attribute to individual cells for specific widths. Sized cells can be
+                    used in any position within a row. Other cells in a row without sizing divide up the remaining
+                    space.
+                </p>
+                <p>
+                    The available sizes are:
                 </p>
                 <ul>
                     <li>1of2</li>

--- a/src/rb-grid/demo/demo.tpl.html
+++ b/src/rb-grid/demo/demo.tpl.html
@@ -105,6 +105,40 @@
                     </rb-grid-cell>
                 </rb-grid>
                 <rb-grid>
+                    <rb-grid-cell>
+                        <rb-demo-block>
+                            auto
+                        </rb-demo-block>
+                    </rb-grid-cell>
+                    <rb-grid-cell>
+                        <rb-demo-block>
+                            auto
+                        </rb-demo-block>
+                    </rb-grid-cell>
+                    <rb-grid-cell size="1of2">
+                        <rb-demo-block>
+                            1 of 2
+                        </rb-demo-block>
+                    </rb-grid-cell>
+                </rb-grid>
+                <rb-grid>
+                    <rb-grid-cell>
+                        <rb-demo-block>
+                            auto
+                        </rb-demo-block>
+                    </rb-grid-cell>
+                    <rb-grid-cell size="1of2">
+                        <rb-demo-block>
+                            1 of 2
+                        </rb-demo-block>
+                    </rb-grid-cell>
+                    <rb-grid-cell>
+                        <rb-demo-block>
+                            auto
+                        </rb-demo-block>
+                    </rb-grid-cell>
+                </rb-grid>
+                <rb-grid>
                     <rb-grid-cell size="1of3">
                         <rb-demo-block>
                             1 of 3

--- a/src/rb-grid/demo/demo.tpl.html
+++ b/src/rb-grid/demo/demo.tpl.html
@@ -82,14 +82,14 @@
                 <p>
                     Add the <code>size</code> attribute to individual cells for specific widths. Cells without sizing classes divide up the
                     remaining space. The available sizes are:
-                    <ul>
-                     <li>1of2</li>
-                     <li>1of3</li>
-                     <li>2of3</li>
-                     <li>1of4</li>
-                     <li>3of4</li>
-                    </ul>
                 </p>
+                <ul>
+                    <li>1of2</li>
+                    <li>1of3</li>
+                    <li>2of3</li>
+                    <li>1of4</li>
+                    <li>3of4</li>
+                </ul>
             </div>
             <div class="ComponentView">
                 <rb-grid>


### PR DESCRIPTION
* Add mid-row grid size demo examples (just for `10f2`, too verbose doing it for all of them).
* Fix grid invidual sizing explanation.
* Fix bad nesting: had a block-level element (`<ul>`) inside a block level element (`<p>`).