### PR TITLE
Only display category if not hidden

### DIFF
--- a/src/rb-scrollspy/rb-scrollspy.tpl.html
+++ b/src/rb-scrollspy/rb-scrollspy.tpl.html
@@ -1,12 +1,12 @@
 <div>
     <ul du-scroll-container="{{scrollId}}" du-spy-context>
         <li ng-repeat="category in categories">
-            <a class="Scrollspy-Category"
-               href="#{{::category.anchor}}"
-               du-scrollspy
-               du-smooth-scroll
-               offset="{{offset || 0}}"
-               ng-class="{'Scrollspy-Category--hidden': category.hidden}"
+            <a ng-if="!category.hidden"
+                class="Scrollspy-Category"
+                href="#{{::category.anchor}}"
+                du-scrollspy
+                du-smooth-scroll
+                offset="{{offset || 0}}"
             >
                 <span>{{::category.label}}</span>
             </a>

--- a/test/unit/rb-scrollspy/rb-scrollspy.spec.js
+++ b/test/unit/rb-scrollspy/rb-scrollspy.spec.js
@@ -13,7 +13,7 @@ define([
                 {
                     'label': 'Countries',
                     'anchor': 'countries',
-                    'hidden': true,
+                    'hidden': false,
                     'items': [
                         {
                             'label': 'A',
@@ -170,6 +170,15 @@ define([
                     compileTemplate(template);
 
                     expect(angular.element(element.find('a')[0]).hasClass('Scrollspy-Category')).toBe(true);
+                });
+
+                it('should not display the top category if set as hidden', function () {
+                    // Ensure not to amend the categories for other tests therefor copy the main list and re-assign
+                    $scope.categories = angular.copy(_categories);
+                    $scope.categories[0].hidden = true;
+                    compileTemplate(template);
+
+                    expect(angular.element(element.find('a')[0]).hasClass('Scrollspy-Category')).toBeFalsy();
                 });
 
                 it('should attach a section class when an item is not a category', function () {


### PR DESCRIPTION
Fixes a bug where the main category class wasn't hidden and affecting the top scroll spy category.

TP: https://rockabox.tpondemand.com/entity/9883
