### PR TITLE
`rb-section` should use heading as attribute, not title

### DIFF
--- a/dev/demo.tpl.html
+++ b/dev/demo.tpl.html
@@ -3,7 +3,7 @@
         <rb-main>
             <rb-page-title heading="Rockabox UI Components">
             </rb-page-title>
-            <rb-section title="Components" hide-title="true">
+            <rb-section heading="Components" hide-heading="true">
                 <ul>
                     <li ng-repeat="state in states" ng-if="state.name != 'app'"><a class="u-linkDefault" ui-sref="{{ state.name }}">{{ state.name }}</a></li>
                 </ul>

--- a/src/rb-action-bar/demo/demo.tpl.html
+++ b/src/rb-action-bar/demo/demo.tpl.html
@@ -2,14 +2,14 @@
     <rb-main>
         <rb-page-title heading="rb-action-bar">
         </rb-page-title>
-        <rb-section title="Introduction" hide-title="true">
+        <rb-section heading="Introduction" hide-heading="true">
             <div class="RawHTML">
                 <p>
                     The <code>rb-action-bar</code> component...
                 </p>
             </div>
         </rb-section>
-        <rb-section title="Column Modifier">
+        <rb-section heading="Column Modifier">
             <div class="ComponentView">
                 <div class="ActionBar  ActionBar--column">
                     <div class="ActionBar-message">
@@ -28,7 +28,7 @@
                 </div>
             </div>
         </rb-section>
-        <rb-section title="Row Modifier">
+        <rb-section heading="Row Modifier">
             <div class="ComponentView">
                 <div class="ActionBar ActionBar--row">
                     <div class="ActionBar-message">

--- a/src/rb-badge/demo/demo.tpl.html
+++ b/src/rb-badge/demo/demo.tpl.html
@@ -2,7 +2,7 @@
     <rb-main>
         <rb-page-title heading="rb-badge">
         </rb-page-title>
-        <rb-section title="Introduction" hide-title="true">
+        <rb-section heading="Introduction" hide-heading="true">
             <div class="RawHTML">
                 <p>
                     The <code>rb-badge</code> component displays Badge-style messaging for <code>warning</code> and
@@ -17,7 +17,7 @@
                 </p>
             </div>
         </rb-section>
-        <rb-section title="Warning">
+        <rb-section heading="Warning">
             <div class="ComponentView">
                 <rb-badge body="6" state="warning" collapsed="true"></rb-badge>
             </div>
@@ -25,7 +25,7 @@
                 <rb-badge body="6" state="warning" collapsed="false"></rb-badge>
             </div>
         </rb-section>
-        <rb-section title="Status">
+        <rb-section heading="Status">
             <div class="ComponentView ComponentView--grid">
                 <rb-badge state="statusIncomplete" collapsed="true"></rb-badge>
                 <rb-badge state="statusLive" collapsed="true"></rb-badge>

--- a/src/rb-button/demo/demo.tpl.html
+++ b/src/rb-button/demo/demo.tpl.html
@@ -2,7 +2,7 @@
     <rb-main>
         <rb-page-title heading="rb-button">
         </rb-page-title>
-        <rb-section title="Introduction" hide-title="true">
+        <rb-section heading="Introduction" hide-heading="true">
             <div class="RawHTML">
                 <p>
                     The <code>rb-button</code> component defines button styles for <code>&lt;button&gt;</code> and
@@ -14,7 +14,7 @@
                 </p>
             </div>
         </rb-section>
-        <rb-section title="Default">
+        <rb-section heading="Default">
             <div class="ComponentView ComponentView--grid">
                 <rb-button>Standard Button</rb-button>
                 <rb-button type="submit">Standard Submit</rb-button>
@@ -26,13 +26,13 @@
                 <rb-button href="http://example.com/" outline="yes">Outline Link</rb-button>
             </div>
         </rb-section>
-        <rb-section title="Disabled State">
+        <rb-section heading="Disabled State">
             <div class="ComponentView ComponentView--grid">
                 <rb-button ng-disabled="true" type="button">Disabled Button</rb-button>
                 <rb-button ng-disabled="true" outline="yes" type="button">Disabled Button</rb-button>
             </div>
         </rb-section>
-        <rb-section title="Secondary Modifiers">
+        <rb-section heading="Secondary Modifiers">
             <div class="RawHTML">
                 <p>
                     Change the size or colour of a button.

--- a/src/rb-check-control/demo/demo-group.tpl.html
+++ b/src/rb-check-control/demo/demo-group.tpl.html
@@ -2,14 +2,14 @@
     <rb-main>
         <rb-page-title heading="rb-check-control-group">
         </rb-page-title>
-        <rb-section title="Introduction" hide-title="true">
+        <rb-section heading="Introduction" hide-heading="true">
             <div class="RawHTML">
                 <p>
                     A check control group displays a group of check controls
                 </p>
             </div>
         </rb-section>
-        <rb-section title="Examples" hide-title="true">
+        <rb-section heading="Examples" hide-heading="true">
             <div class="ComponentView">
                 <form name="checkControlForm">
                     <rb-check-control-group

--- a/src/rb-check-control/demo/demo.tpl.html
+++ b/src/rb-check-control/demo/demo.tpl.html
@@ -2,7 +2,7 @@
     <rb-main>
         <rb-page-title heading="rb-check-control">
         </rb-page-title>
-        <rb-section title="Introduction" hide-title="true">
+        <rb-section heading="Introduction" hide-heading="true">
             <div class="RawHTML">
                 <p>
                     A check control displays a single checkbox/label pair (cf. <code>rb-radio-control</code>).
@@ -15,7 +15,7 @@
                 </p>
             </div>
         </rb-section>
-        <rb-section title="Current Angular Version">
+        <rb-section heading="Current Angular Version">
             <form name="checkControlForm">
                 <div class="RawHTML">
                     <h4>Default</h4>
@@ -82,7 +82,7 @@
                 </div>
             </form>
         </rb-section>
-        <rb-section title="Static Reference Version">
+        <rb-section heading="Static Reference Version">
             <div class="RawHTML">
                 <h4>
                     Default

--- a/src/rb-check-with-text-control-group/demo/demo.tpl.html
+++ b/src/rb-check-with-text-control-group/demo/demo.tpl.html
@@ -2,13 +2,13 @@
     <rb-main>
         <rb-page-title heading="rb-check-with-text-control-group">
         </rb-page-title>
-        <rb-section title="Introduction" hide-title="true">
+        <rb-section heading="Introduction" hide-heading="true">
             <div class="RawHTML">
                 The <code>rb-check-with-text-control-group</code> component renders a group of
                 <code>rb-check-with-text-control</code> components.
             </div>
         </rb-section>
-        <rb-section title="Normal">
+        <rb-section heading="Normal">
             <div class="ComponentView">
                 <form name="myForm">
                     <rb-check-with-text-control-group
@@ -25,7 +25,7 @@
                 </form>
             </div>
         </rb-section>
-        <rb-section title="Pre-populated">
+        <rb-section heading="Pre-populated">
             <div class="ComponentView">
                 <form name="myForm">
                     <rb-check-with-text-control-group
@@ -42,7 +42,7 @@
                 </form>
             </div>
         </rb-section>
-        <rb-section title="Watching External Changes">
+        <rb-section heading="Watching External Changes">
             <div class="ComponentView">
                 <form name="myForm">
                     <rb-check-with-text-control-group

--- a/src/rb-check-with-text-control/demo/demo.tpl.html
+++ b/src/rb-check-with-text-control/demo/demo.tpl.html
@@ -2,7 +2,7 @@
     <rb-main>
         <rb-page-title heading="rb-check-with-text-control">
         </rb-page-title>
-        <rb-section title="Introduction" hide-title="true">
+        <rb-section heading="Introduction" hide-heading="true">
             <div class="RawHTML">
                 <p>
                     The <code>rb-check-with-text-control</code> component consists of a checkbox that, when clicked,
@@ -10,7 +10,7 @@
                 </p>
             </div>
         </rb-section>
-        <rb-section title="Empty">
+        <rb-section heading="Empty">
             <div class="ComponentView">
                 <rb-check-with-text-control
                     name="empty"
@@ -23,7 +23,7 @@
                 Model: {{demoCtrl.models.empty}}
             </div>
         </rb-section>
-        <rb-section title="Pre-populated">
+        <rb-section heading="Pre-populated">
             <div class="ComponentView">
                 <rb-check-with-text-control
                     name="prepopulated"
@@ -36,7 +36,7 @@
                 Model: {{demoCtrl.models.prepopulated}}
             </div>
         </rb-section>
-        <rb-section title="With Placeholder">
+        <rb-section heading="With Placeholder">
             <div class="ComponentView">
                 <rb-check-with-text-control
                     name="placeholder"
@@ -50,7 +50,7 @@
                 Model: {{demoCtrl.models.placeholder}}
             </div>
         </rb-section>
-        <rb-section title="With Form Validation">
+        <rb-section heading="With Form Validation">
             <div class="ComponentView">
                 <form name="demoCtrl.myForm">
                     <rb-check-with-text-control

--- a/src/rb-currency-display/demo/demo.tpl.html
+++ b/src/rb-currency-display/demo/demo.tpl.html
@@ -2,7 +2,7 @@
     <rb-main>
         <rb-page-title heading="rb-currency-display">
         </rb-page-title>
-        <rb-section title="Introduction" hide-title="true">
+        <rb-section heading="Introduction" hide-heading="true">
             <div class="RawHTML">
                 <p>
                     The <code>rb-currency-display</code> component must be used to render all representations of a currency. It
@@ -10,32 +10,32 @@
                 </p>
             </div>
         </rb-section>
-        <rb-section title="Currency With Decimal Passed">
+        <rb-section heading="Currency With Decimal Passed">
             <div class="ComponentView">
                 <rb-currency-display amount="{{ demoCtrl.currency.withDec }}"></rb-currency-display>
             </div>
         </rb-section>
-        <rb-section title="Currency With No Decimal Passed">
+        <rb-section heading="Currency With No Decimal Passed">
             <div class="ComponentView">
                 <rb-currency-display amount="{{ demoCtrl.currency.withoutDec }}"></rb-currency-display>
             </div>
         </rb-section>
-        <rb-section title="Currency With 0 Passed As Decimal (Rounded)">
+        <rb-section heading="Currency With 0 Passed As Decimal (Rounded)">
             <div class="ComponentView">
                 <rb-currency-display decimal-places="0" amount="{{ demoCtrl.currency.withDec }}"></rb-currency-display>
             </div>
         </rb-section>
-        <rb-section title="Currency With 1 Decimal Place">
+        <rb-section heading="Currency With 1 Decimal Place">
             <div class="ComponentView">
                 <rb-currency-display decimal-places="1" amount="{{ demoCtrl.currency.roundDec }}"></rb-currency-display>
             </div>
         </rb-section>
-        <rb-section title="Currency With 2 Decimal Places">
+        <rb-section heading="Currency With 2 Decimal Places">
             <div class="ComponentView">
                 <rb-currency-display decimal-places="2" amount="{{ demoCtrl.currency.roundDec }}"></rb-currency-display>
             </div>
         </rb-section>
-        <rb-section title="Currency With 3 Decimal Places">
+        <rb-section heading="Currency With 3 Decimal Places">
             <div class="ComponentView">
                 <rb-currency-display decimal-places="3" amount="{{ demoCtrl.currency.roundDec }}"></rb-currency-display>
             </div>

--- a/src/rb-data-summary/demo/demo.tpl.html
+++ b/src/rb-data-summary/demo/demo.tpl.html
@@ -2,14 +2,14 @@
     <rb-main>
         <rb-page-title heading="rb-data-summary">
         </rb-page-title>
-        <rb-section title="Introduction" hide-title="true">
+        <rb-section heading="Introduction" hide-heading="true">
             <div class="RawHTML">
                 <p>
                     The <code>rb-data-summary</code> component can be used to represent summary data for a particular item.
                 </p>
             </div>
         </rb-section>
-        <rb-section title="Financials Modifier">
+        <rb-section heading="Financials Modifier">
             <div class="ComponentView">
                 <rb-data-summary type="financials">
                     <rb-data-summary-item header="Total Campaign Spend ⁄ Budget">
@@ -23,7 +23,7 @@
                 </rb-data-summary>
             </div>
         </rb-section>
-        <rb-section title="Timings Modifier">
+        <rb-section heading="Timings Modifier">
             <div class="ComponentView">
                 <rb-data-summary type="timings">
                     <rb-data-summary-item header="Campaign Start">
@@ -39,7 +39,7 @@
                 </rb-data-summary>
             </div>
         </rb-section>
-        <rb-section title="Notes Modifier">
+        <rb-section heading="Notes Modifier">
             <div class="ComponentView">
                 <rb-data-summary type="notes">
                     <rb-data-summary-item header="Sector">
@@ -64,7 +64,7 @@
                 </rb-data-summary>
             </div>
         </rb-section>
-        <rb-section title="Notes Modifier, Line Item Example">
+        <rb-section heading="Notes Modifier, Line Item Example">
             <div class="ComponentView">
                 <rb-data-summary type="notes">
                     <rb-data-summary-item header="Daily Budget">

--- a/src/rb-datetime-control/demo/demo.tpl.html
+++ b/src/rb-datetime-control/demo/demo.tpl.html
@@ -3,7 +3,7 @@
         <rb-page-title heading="rb-datetime-control">
         </rb-page-title>
         <form name="basicForm">
-            <rb-section title="Basic Usage">
+            <rb-section heading="Basic Usage">
                 <div class="ComponentView">
                     <rb-datetime-control name="basic" form="basicForm" label="Date time" ng-model="demoCtrl.data.basic"></rb-datetime-control>
                     <h3>
@@ -14,7 +14,7 @@
                     </div>
                 </div>
             </rb-section>
-            <rb-section title="Date Only">
+            <rb-section heading="Date Only">
                 <div class="ComponentView">
                     <rb-datetime-control
                         disable-time="true"
@@ -31,7 +31,7 @@
                     </div>
                 </div>
             </rb-section>
-            <rb-section title="With Required">
+            <rb-section heading="With Required">
                 <div class="ComponentView">
                     <rb-datetime-control name="required" form="basicForm" is-required="true" label="Date time" ng-model="demoCtrl.data.required"></rb-datetime-control>
                     <h3>Scope value (UTC):</h3>
@@ -40,7 +40,7 @@
                     </div>
                 </div>
             </rb-section>
-            <rb-section title="With Help Message">
+            <rb-section heading="With Help Message">
                 <div class="ComponentView">
                     <rb-datetime-control name="help" form="basicForm" help-message="Please enter a date and time" label="Date time" ng-model="demoCtrl.data.help"></rb-datetime-control>
                     <h3>
@@ -51,7 +51,7 @@
                     </div>
                 </div>
             </rb-section>
-            <rb-section title="With Placeholder">
+            <rb-section heading="With Placeholder">
                 <div class="ComponentView">
                     <rb-datetime-control name="placeholder" form="basicForm" placeholder-date="DD/MM/YY" placeholder-time="HH:MM" label="Date time" ng-model="demoCtrl.data.placeholder"></rb-datetime-control>
                     <h3>
@@ -62,7 +62,7 @@
                     </div>
                 </div>
             </rb-section>
-            <rb-section title="With Inherited Date Time">
+            <rb-section heading="With Inherited Date Time">
                 <div class="ComponentView">
                     <rb-datetime-control name="placeholder" form="basicForm" inherit-label="Inherit date/time from somehwere else." inherit-datetime="{{demoCtrl.inheritDatetime}}" placeholder-date="DD/MM/YY" placeholder-time="HH:MM" label="Date time" ng-model="demoCtrl.data.inherit" inherit-model='demoCtrl.data.inheritModel'></rb-datetime-control>
                     <h3>
@@ -73,7 +73,7 @@
                     </div>
                 </div>
             </rb-section>
-            <rb-section title="With Preset Inherited Date Time">
+            <rb-section heading="With Preset Inherited Date Time">
                 <div class="ComponentView">
                     <rb-datetime-control name="placeholder" form="basicForm" inherit-label="Inherit date/time from somehwere else." inherit-datetime="{{demoCtrl.inheritDatetime}}" placeholder-date="DD/MM/YY" placeholder-time="HH:MM" label="Date time" ng-model="demoCtrl.data.presetInherit" inherit-model='demoCtrl.data.inheritModelTrue'></rb-datetime-control>
                     <h3>
@@ -84,7 +84,7 @@
                     </div>
                 </div>
             </rb-section>
-            <rb-section title="With Inherited Date And is-disabled">
+            <rb-section heading="With Inherited Date And is-disabled">
                 <div class="ComponentView">
                     <rb-datetime-control name="placeholder" is-disabled="true" form="basicForm" inherit-label="Inherit date/time from somehwere else." inherit-datetime="{{demoCtrl.inheritDatetime}}" placeholder-date="DD/MM/YY" placeholder-time="HH:MM" label="Date time" ng-model="demoCtrl.data.disabled"></rb-datetime-control>
                     <h3>

--- a/src/rb-datetime-display/demo/demo.tpl.html
+++ b/src/rb-datetime-display/demo/demo.tpl.html
@@ -2,7 +2,7 @@
     <rb-main>
         <rb-page-title heading="rb-datetime-display">
         </rb-page-title>
-        <rb-section title="Introduction" hide-title="true">
+        <rb-section heading="Introduction" hide-heading="true">
             <div class="RawHTML">
                 <p>
                     The <code>rb-datetime-display</code> component must be used to render all representations of dates and
@@ -10,17 +10,17 @@
                 </p>
             </div>
         </rb-section>
-        <rb-section title="rb-date-time-display With Time">
+        <rb-section heading="rb-date-time-display With Time">
             <div class="ComponentView">
                 <rb-datetime-display date-time="{{ demoCtrl.date }}"></rb-datetime-display>
             </div>
         </rb-section>
-        <rb-section title="rb-date-time-display With Understated Time">
+        <rb-section heading="rb-date-time-display With Understated Time">
             <div class="ComponentView">
                 <rb-datetime-display date-time="{{ demoCtrl.date }}" understate-time="true"></rb-datetime-display>
             </div>
         </rb-section>
-        <rb-section title="rb-date-time-display Without Time">
+        <rb-section heading="rb-date-time-display Without Time">
             <div class="ComponentView">
                 <rb-datetime-display date-time="{{ demoCtrl.date }}" show-time="false"></rb-datetime-display>
             </div>

--- a/src/rb-deep-search/demo/demo.tpl.html
+++ b/src/rb-deep-search/demo/demo.tpl.html
@@ -1,7 +1,7 @@
 <rb-site>
     <rb-main>
         <rb-page-title heading="rb-deep-search"></rb-page-title>
-        <rb-section title="Introduction" hide-title="true">
+        <rb-section heading="Introduction" hide-heading="true">
             <div class="RawHTML">
                 <p>
                     The <code>rb-deep-search</code> component search through an object and set

--- a/src/rb-demo-block/demo/demo.tpl.html
+++ b/src/rb-demo-block/demo/demo.tpl.html
@@ -2,7 +2,7 @@
     <rb-main>
         <rb-page-title heading="rb-demo-block">
         </rb-page-title>
-        <rb-section title="Introduction" hide-title="true">
+        <rb-section heading="Introduction" hide-heading="true">
             <div class="RawHTML">
                 <p>
                     The <code>rb-demo-block</code> component is a block-level placeholder component, used for testing

--- a/src/rb-generic-form/demo/demo.tpl.html
+++ b/src/rb-generic-form/demo/demo.tpl.html
@@ -2,7 +2,7 @@
     <rb-main>
         <rb-page-title heading="rb-generic-form">
         </rb-page-title>
-        <rb-section title="Introduction" hide-title="true">
+        <rb-section heading="Introduction" hide-heading="true">
             <div class="RawHTML">
                 <p>
                     The <code>rb-generic-form</code> component should be used to wrap generic forms. Custom forms have their own
@@ -16,7 +16,7 @@
                 </p>
             </div>
         </rb-section>
-        <rb-section title="With Message">
+        <rb-section heading="With Message">
             <div class="ComponentView">
                 <form class="GenericForm">
                     <div class="GenericForm-message">
@@ -44,7 +44,7 @@
                 </form>
             </div>
         </rb-section>
-        <rb-section title="Without Message">
+        <rb-section heading="Without Message">
             <div class="ComponentView">
                 <form class="GenericForm">
                     <div class="GenericForm-body">

--- a/src/rb-grid/demo/demo.tpl.html
+++ b/src/rb-grid/demo/demo.tpl.html
@@ -2,7 +2,7 @@
     <rb-main>
         <rb-page-title heading="rb-grid">
         </rb-page-title>
-        <rb-section title="Introduction" hide-title="true">
+        <rb-section heading="Introduction" hide-heading="true">
             <div class="RawHTML">
                 <p>
                     The <code>rb-grid</code> component arranges other components in a grid layout at medium viewport and above.
@@ -10,7 +10,7 @@
                 </p>
             </div>
         </rb-section>
-        <rb-section title="Basic Grids">
+        <rb-section heading="Basic Grids">
             <div class="RawHTML">
                 <p>
                     Each <code>rb-grid-cell</code> in a row will have the same width.
@@ -77,7 +77,7 @@
                 </rb-grid>
             </div>
         </rb-section>
-        <rb-section title="Individual Sizing">
+        <rb-section heading="Individual Sizing">
             <div class="RawHTML">
                 <p>
                     Add the <code>size</code> attribute to individual cells for specific widths. Sized cells can be
@@ -192,7 +192,7 @@
                 </rb-grid>
             </div>
         </rb-section>
-        <rb-section title="Gutterless Grid">
+        <rb-section heading="Gutterless Grid">
             <div class="RawHTML">
                 <p>
                     You can control the grid gutters with the <code>gutter</code> attribute. It defaults to true.
@@ -220,7 +220,7 @@
                 </rb-grid>
             </div>
         </rb-section>
-        <rb-section title="Grid flex">
+        <rb-section heading="Grid flex">
             <div class="RawHTML">
                 <p>
                     You can control the flex of the grid cells using the <code>flex-cells</code> attribute. It defaults to true.

--- a/src/rb-overlay-panel/demo/demo.tpl.html
+++ b/src/rb-overlay-panel/demo/demo.tpl.html
@@ -2,14 +2,14 @@
     <rb-main>
         <rb-page-title heading="rb-overlay-panel">
         </rb-page-title>
-        <rb-section title="Introduction" hide-title="true">
+        <rb-section heading="Introduction" hide-heading="true">
             <div class="RawHTML">
                 <p>
                     The <code>rb-overlay-panel</code> component creates a wrapper for an overlay panel.
                 </p>
             </div>
         </rb-section>
-        <rb-section title="Demo">
+        <rb-section heading="Demo">
             <div class="RawHTML">
                 <p>
                     Cupiditate rerum blanditiis quae asperiores et, <rb-button ng-click="demoRbOverlayPanelCtrl.showOverlay = true">Display Overlay</rb-button> omnis voluptates ut dolor accusantium nobis beatae aliquid sunt ea nulla sequi fugit ratione, qui odio at numquam illum! Dolorum velit ipsam id numquam.
@@ -99,7 +99,7 @@
                     </rb-page-title>
                 </div>
                 <div class="PanelScroll-scrollable">
-                    <rb-section title="Section heading" hide-title="true">
+                    <rb-section heading="Section heading" hide-heading="true">
                         <p>
                             Scrollable contents.
                         </p>

--- a/src/rb-panel-scroll/demo/demo.tpl.html
+++ b/src/rb-panel-scroll/demo/demo.tpl.html
@@ -2,7 +2,7 @@
     <rb-main>
         <rb-page-title heading="rb-panel-scroll">
         </rb-page-title>
-        <rb-section title="Introduction" hide-title="true">
+        <rb-section heading="Introduction" hide-heading="true">
             <div class="RawHTML">
                 <p>
                     The <code>rb-panel-scroll</code> component is a wrapper component that creates a scrollable area
@@ -10,7 +10,7 @@
                 </p>
             </div>
         </rb-section>
-        <rb-section title="Demo">
+        <rb-section heading="Demo">
             <rb-panel-scroll></rb-panel-scroll>
         </rb-section>
     </rb-main>

--- a/src/rb-section/demo/demo.tpl.html
+++ b/src/rb-section/demo/demo.tpl.html
@@ -11,7 +11,7 @@
         </h3>
     </div>
     <div class="ComponentView">
-        <rb-section title="Section heading">
+        <rb-section heading="Section heading">
             Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod
             tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,
             quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
@@ -26,7 +26,7 @@
         </h3>
     </div>
     <div class="ComponentView">
-        <rb-section title="Section heading" gutterless="true">
+        <rb-section heading="Section heading" gutterless="true">
             Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod
             tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,
             quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
@@ -41,7 +41,7 @@
         </h3>
     </div>
     <div class="ComponentView">
-        <rb-section title="Section heading" hide-title="true">
+        <rb-section heading="Section heading" hide-heading="true">
             ↑↑↑ Hidden <code>.Section</code> heading here ↑↑↑
         </section>
     </div>

--- a/src/rb-section/rb-section-directive.js
+++ b/src/rb-section/rb-section-directive.js
@@ -23,9 +23,9 @@ define([
 
         return {
             scope: {
-                title: '@',
+                heading: '@',
                 gutterless: '@',
-                hideTitle: '@'
+                hideHeading: '@'
             },
             restrict: 'E',
             replace: true,

--- a/src/rb-section/rb-section.css
+++ b/src/rb-section/rb-section.css
@@ -33,6 +33,6 @@
     padding: 0; /* 2 */
 }
 
-.Section--gutterless .Section-title {
+.Section--gutterless .Section-heading {
     padding: 0 var(--layout-gutter);
 }

--- a/src/rb-section/rb-section.tpl.html
+++ b/src/rb-section/rb-section.tpl.html
@@ -1,6 +1,6 @@
 <section class="Section" ng-class="{'Section--gutterless': gutterless == 'true'}">
-    <div class="Section-title" ng-class="{'u-hiddenVisually': hideTitle == 'true'}">
-        <h2 class="u-textHeading2 u-textKeyline">{{ ::title }}</h2>
+    <div class="Section-heading" ng-class="{'u-hiddenVisually': hideHeading == 'true'}">
+        <h2 class="u-textHeading2 u-textKeyline">{{ ::heading }}</h2>
     </div>
     <div class="Section-body" ng-transclude></div>
 </section>

--- a/src/rb-side-nav/demo/demo.tpl.html
+++ b/src/rb-side-nav/demo/demo.tpl.html
@@ -2,7 +2,7 @@
     <rb-main>
         <rb-page-title heading="rb-side-nav">
         </rb-page-title>
-        <rb-section title="With On Save And On Cancel">
+        <rb-section heading="With On Save And On Cancel">
             <div class="ComponentView">
                 <rb-side-nav title="A Menu" on-save="demoCtrl.save()" on-cancel="demoCtrl.cancel()">
                     <rb-side-nav-item ui-sref="rb-badge" label="Menu Item 1"></rb-side-nav-item>
@@ -11,36 +11,36 @@
                 </rb-side-nav>
             </div>
         </rb-section>
-        <rb-section title="Sidenav With Disabled Save">
+        <rb-section heading="Sidenav With Disabled Save">
             <div class="ComponentView">
                 <rb-side-nav title="A Menu" on-save="demoCtrl.save()" on-cancel="demoCtrl.cancel()" save-button-disabled="true"></rb-side-nav>
             </div>
         </rb-section>
-        <rb-section title="Sidenav With Save Label">
+        <rb-section heading="Sidenav With Save Label">
             <div class="ComponentView">
                 <rb-side-nav title="A Menu" save-label="Save &amp; Republish"></rb-side-nav>
             </div>
         </rb-section>
-        <rb-section title="Sidenav With Action Help Text">
+        <rb-section heading="Sidenav With Action Help Text">
             <div class="ComponentView">
                 <rb-side-nav title="A Menu" action-help-text="Be careful when hitting save!"></rb-side-nav>
             </div>
         </rb-section>
-        <rb-section title="Sidenav Item Basic">
+        <rb-section heading="Sidenav Item Basic">
             <div class="ComponentView">
                 <ul>
                     <rb-side-nav-item ui-sref="rb-badge" label="Menu Item 1"></rb-side-nav-item>
                 </ul>
             </div>
         </rb-section>
-        <rb-section title="Sidenav Item Active">
+        <rb-section heading="Sidenav Item Active">
             <div class="ComponentView">
                 <ul>
                     <rb-side-nav-item ui-sref="rb-badge" active="true" label="Menu Item 1"></rb-side-nav-item>
                 </ul>
             </div>
         </rb-section>
-        <rb-section title="Sidenav Item With Count">
+        <rb-section heading="Sidenav Item With Count">
             <div class="ComponentView">
                 <ul>
                     <rb-side-nav-item ui-sref="rb-badge" count="20" label="Menu Item 1"></rb-side-nav-item>
@@ -48,21 +48,21 @@
                 </ul>
             </div>
         </rb-section>
-        <rb-section title="Sidenav Item With Icon">
+        <rb-section heading="Sidenav Item With Icon">
             <div class="ComponentView">
                 <ul>
                     <rb-side-nav-item ui-sref="rb-badge" icon="gray-ghost-16-frequency" label="Menu Item 1"></rb-side-nav-item>
                 </ul>
             </div>
         </rb-section>
-        <rb-section title="Sidenav Item With Invalid">
+        <rb-section heading="Sidenav Item With Invalid">
             <div class="ComponentView">
                 <ul>
                     <rb-side-nav-item ui-sref="rb-badge" invalid="true" label="Menu Item 1"></rb-side-nav-item>
                 </ul>
             </div>
         </rb-section>
-        <rb-section title="Sidenav Item With Valid">
+        <rb-section heading="Sidenav Item With Valid">
             <div class="ComponentView">
                 <ul>
                     <rb-side-nav-item ui-sref="rb-badge" valid="true" label="Menu Item 1"></rb-side-nav-item>

--- a/src/rb-text-control/demo/demo.tpl.html
+++ b/src/rb-text-control/demo/demo.tpl.html
@@ -5,7 +5,7 @@
             <rb-page-title heading="rb-text-control">
             </rb-page-title>
 
-            <rb-section title="Text (type='text')">
+            <rb-section heading="Text (type='text')">
                 <rb-text-control
                     form="userForm"
                     label="Pet Name"
@@ -18,7 +18,7 @@
                 </rb-text-control>
             </rb-section>
 
-            <rb-section title="Email (type='email')">
+            <rb-section heading="Email (type='email')">
                 <rb-text-control
                     form="userForm"
                     label="Your Email"
@@ -31,7 +31,7 @@
                 </rb-text-control>
             </rb-section>
 
-            <rb-section title="Password (type='password')">
+            <rb-section heading="Password (type='password')">
                 <rb-text-control
                     form="userForm"
                     label="Your favorite password"
@@ -43,7 +43,7 @@
                 </rb-text-control>
             </rb-section>
 
-            <rb-section title="Number (type='number')">
+            <rb-section heading="Number (type='number')">
                 <rb-text-control
                     form="userForm"
                     label="How cool is Nick on a scale of 1-10?"
@@ -55,7 +55,7 @@
                 </rb-text-control>
             </rb-section>
 
-            <rb-section title="Currency (type='currency')">
+            <rb-section heading="Currency (type='currency')">
                 <rb-text-control
                     form="userForm"
                     label="Currency"
@@ -68,7 +68,7 @@
                 </rb-text-control>
             </rb-section>
 
-            <rb-section title="Small (small='true')">
+            <rb-section heading="Small (small='true')">
                 <rb-text-control
                     form="userForm"
                     label="Something insignificant"
@@ -80,7 +80,7 @@
                 </rb-text-control>
             </rb-section>
 
-            <rb-section title="Textarea (type='textarea')">
+            <rb-section heading="Textarea (type='textarea')">
                 <rb-text-control
                     form="userForm"
                     label="Description (non-elastic textarea)"
@@ -101,7 +101,7 @@
                 </rb-text-control>
             </rb-section>
 
-            <rb-section title="Search (type='search')">
+            <rb-section heading="Search (type='search')">
                 <rb-text-control
                     form="userForm"
                     label="What are you looking for?"
@@ -112,7 +112,7 @@
                 </rb-text-control>
             </rb-section>
 
-            <rb-section title="Readonly textarea (is-readonly='true')">
+            <rb-section heading="Readonly textarea (is-readonly='true')">
                 <rb-text-control
                     form="userForm"
                     name="readonly_message"
@@ -122,7 +122,7 @@
                 </rb-text-control>
             </rb-section>
 
-            <rb-section title="Server Validation">
+            <rb-section heading="Server Validation">
                 <rb-text-control
                     form="userForm"
                     label="Validated on server"
@@ -142,7 +142,7 @@
                 </rb-text-control>
             </rb-section>
 
-            <rb-section title="Demo Form Summary">
+            <rb-section heading="Demo Form Summary">
                 <div ng-if="userForm.$valid">
                     Form is valid
                 </div>

--- a/test/unit/rb-section/rb-section.spec.js
+++ b/test/unit/rb-section/rb-section.spec.js
@@ -37,8 +37,8 @@ define([
                 expect(ele.text()).toBe('Great!');
             });
 
-            it('should set title from attribute', function () {
-                compileTemplate('<rb-section title="A great thing"></rb-section>');
+            it('should set heading from attribute', function () {
+                compileTemplate('<rb-section heading="A great thing"></rb-section>');
 
                 expect(element.find('h2').length).toBe(1);
                 expect(element.find('h2').hasClass('u-textHeading2')).toBe(true);
@@ -67,23 +67,23 @@ define([
             });
         });
 
-        describe('hide title attribute', function () {
+        describe('hide heading attribute', function () {
 
-            it('should hide title when the value is true', function () {
-                compileTemplate('<rb-section hide-title="true"></rb-section>');
+            it('should hide heading when the value is true', function () {
+                compileTemplate('<rb-section hide-heading="true"></rb-section>');
 
-                var ele = angular.element(element[0].querySelector('.Section-title'));
+                var ele = angular.element(element[0].querySelector('.Section-heading'));
 
                 expect(ele.hasClass('u-hiddenVisually')).toBe(true);
             });
 
-            it('should not hide title when the value is false', function () {
-                compileTemplate('<rb-section hide-title="false"></rb-section>');
+            it('should not hide heading when the value is false', function () {
+                compileTemplate('<rb-section hide-heading="false"></rb-section>');
 
                 expect(element.find('h2').hasClass('u-hiddenVisually')).toBe(false);
             });
 
-            it('should not hide title when no value', function () {
+            it('should not hide heading when no value', function () {
                 compileTemplate('<rb-section></rb-section>');
 
                 expect(element.find('h2').hasClass('u-hiddenVisually')).toBe(false);


### PR DESCRIPTION
TP: https://rockabox.tpondemand.com/entity/9755

Stops standard HTML `title` attribute tooltips appearing in component.

Breaking change: merge at the same time as rockabox/rbx_campaign_management/pull/155