### PR TITLE
Fix default implicit ARIA semantics

### DIFF
--- a/src/rb-footer/rb-footer.tpl.html
+++ b/src/rb-footer/rb-footer.tpl.html
@@ -1,4 +1,4 @@
-<footer class="Footer" role="contentinfo">
+<footer class="Footer">
     <ul class="Footer-items">
         <li class="Footer-item" ng-repeat="link in ::links track by $index">
             <a class="Footer-itemInner" ng-click="clickfunction({id:link.id})" ng-aria>{{::link.text}}</a>

--- a/src/rb-main/rb-main.tpl.html
+++ b/src/rb-main/rb-main.tpl.html
@@ -1,2 +1,2 @@
-<main class="Main" role="main" ng-transclude>
+<main class="Main" ng-transclude>
 </main>

--- a/src/rb-nav-bar/rb-nav-bar.tpl.html
+++ b/src/rb-nav-bar/rb-nav-bar.tpl.html
@@ -1,4 +1,4 @@
-<nav class="Navigation" role="navigation">
+<nav class="Navigation">
     <ul class="Navigation-items">
         <li class="Navigation-item" ng-repeat="option in ::options track by $index" ng-switch="!option.state">
             <a


### PR DESCRIPTION
TP: https://rockabox.tpondemand.com/entity/8791

Removes ARIA roles that duplicate semantics implicit in elements.

See: http://html5doctor.com/on-html-belts-and-aria-braces/