### PR TITLE
Remove scroll on whole panel

### DIFF
--- a/src/rb-overlay-panel/rb-overlay-panel.css
+++ b/src/rb-overlay-panel/rb-overlay-panel.css
@@ -17,7 +17,6 @@
     color: var(--color-base-font);
     height: 100%;
     left: 0;
-    overflow-y: scroll;
     position: absolute;
     top: 0;
     width: 85%;


### PR DESCRIPTION
Scrolling can now be per component, not entire overlay panel.

Needs full-height side nav and panel-scroll components in CM before merge.