### PR TITLE
Fix `webpack-dev-middleware` issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "grunt": "~0.4.5",
     "grunt-cli": "~0.1.13",
     "grunt-contrib-jshint": "~0.10.0",
+    "grunt-env": "~0.4.4",
     "grunt-jscs": "~0.7.1",
     "grunt-karma": "~0.8.3",
     "grunt-karma-coveralls": "~2.5.1",
@@ -33,8 +34,8 @@
     "load-grunt-tasks": "~0.6.0",
     "ng-annotate-webpack-plugin": "~0.1.2",
     "webpack": "~1.7.3",
-    "webpack-dev-server": "~1.8.0",
-    "grunt-env": "~0.4.4"
+    "webpack-dev-middleware": "~1.0.11",
+    "webpack-dev-server": "~1.8.0"
   },
   "dependencies": {
     "autoprefixer-core": "~5.2.0",


### PR DESCRIPTION
Dependency of `karma-webpack`.

The bump to [1.2.0](https://github.com/webpack/webpack-dev-middleware/releases/tag/v1.2.0) broke our tests. This fixes version at last known good.