### PR TITLE
Fix timepicker in datetime-control

### DIFF
--- a/src/rb-datetime-control/rb-datetime-control.tpl.html
+++ b/src/rb-datetime-control/rb-datetime-control.tpl.html
@@ -22,7 +22,7 @@
         name="{{timeName}}"
         ng-class="{'is-invalid': form[timeName].$touched && form[timeName].$invalid}"
         ng-disabled="disabledTextInputs()"
-        ng-if="disableTime !== 'true'"
+        ng-show="disableTime !== 'true'"
         ng-model="ngModel"
         ng-required="{{isRequired}}"
         ng-readonly="{{isReadonly}}"

--- a/src/rb-datetime-control/rb-datetime-control.tpl.html
+++ b/src/rb-datetime-control/rb-datetime-control.tpl.html
@@ -43,7 +43,7 @@
         {{ form[name].$error.server }}
     </div>
 
-    <div class="TextControl-message">
+    <div class="TextControl-message" ng-if="disableTime !== 'true'">
         All times are shown in your local time.
     </div>
 

--- a/test/unit/rb-datetime-control/rb-datetime-control.spec.js
+++ b/test/unit/rb-datetime-control/rb-datetime-control.spec.js
@@ -224,9 +224,10 @@ define([
             it('should not show time picker when true', function () {
                 compileTemplate('<rb-datetime-control disable-time="true"></rb-datetime-control>');
 
-                var timePicker = element[0].querySelector('input[bs-timepicker]');
+                var timePicker = angular.element(element[0].querySelector('input[bs-timepicker]'));
 
-                expect(timePicker).toBe(null);
+                // Using ng-show so still renders, but with ng-hide class
+                expect(timePicker.hasClass('ng-hide')).toBe(true);
             });
         });
 

--- a/test/unit/rb-datetime-control/rb-datetime-control.spec.js
+++ b/test/unit/rb-datetime-control/rb-datetime-control.spec.js
@@ -229,6 +229,13 @@ define([
                 // Using ng-show so still renders, but with ng-hide class
                 expect(timePicker.hasClass('ng-hide')).toBe(true);
             });
+
+            it('should not render local time message when true', function () {
+                compileTemplate('<rb-datetime-control disable-time="true"></rb-datetime-control>');
+
+                // Using ng-if, so does not render
+                expect(element.html()).not.toContain('All times are shown in your local time.');
+            });
         });
 
         describe('inherited date time', function () {


### PR DESCRIPTION
Fixed a regression introduced in https://github.com/rockabox/rbx_ui_components/pull/205, where the special scope properties of `ng-if` caused the timepicker to completely break. Tests did not pick up on it as they are unit, not functional.

- Fixed by switching `ng-if` with `ng-show`.
- Also hide local time message when `disable-time` is true

TP https://rockabox.tpondemand.com/entity/9985