### PR TITLE
Angular fieldset actions modifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - [`rb-deep-search` component](https://github.com/rockabox/rbx_ui_components/pull/232)
 - ['rb-scrollspy' do not show hidden sections](https://github.com/rockabox/rbx_ui_components/pull/232)
 - ['rb-check-control-select-all' disabled if all child options are disabled](https://github.com/rockabox/rbx_ui_components/pull/235)
+- ['rb-fieldset' actions modifier](https://github.com/rockabox/rbx_ui_components/pull/271)
+- ['rb-fieldset-item' component](https://github.com/rockabox/rbx_ui_components/pull/271)
 
 ### Changed
 

--- a/src/rb-fieldset/demo/demo.tpl.html
+++ b/src/rb-fieldset/demo/demo.tpl.html
@@ -131,18 +131,14 @@
         </h3>
     </div>
     <div class="ComponentView">
-        <div class="Fieldset Fieldset--actions">
-            <div class="Fieldset-title"></div>
-            <div class="Fieldset-body">
-                <div class="Fieldset-items">
-                    <div class="Fieldset-item">
-                        <rb-button>Action 1</rb-button>
-                    </div>
-                    <div class="Fieldset-item">
-                        <rb-button outline="yes">Action 2</rb-button>
-                    </div>
-                </div>
-            </div>
-        </div>
+        Model: {{demoCtrl.action}}
+        <rb-fieldset type="actions">
+            <rb-fieldset-item>
+                <rb-button ng-click="demoCtrl.action=1">Action 1</rb-button>
+            </rb-fieldset-item>
+            <rb-fieldset-item>
+                <rb-button ng-click="demoCtrl.action=2" outline="yes">Action 2</rb-button>
+            </rb-fieldset-item>
+        </rb-fieldset>
     </div>
 </section>

--- a/src/rb-fieldset/index.js
+++ b/src/rb-fieldset/index.js
@@ -1,7 +1,8 @@
 define([
     './rb-fieldset-directive',
+    './rb-fieldset-item-directive',
     './rb-fieldset.css'
-], function (rbFieldsetDirective, css) {
+], function (rbFieldsetDirective, rbFieldsetItemDirective, css) {
     /**
      * @ngdoc module
      * @name rb-fieldset
@@ -12,7 +13,8 @@ define([
      */
     var rbFieldset = angular
         .module('rb-fieldset', [])
-        .directive('rbFieldset', rbFieldsetDirective);
+        .directive('rbFieldset', rbFieldsetDirective)
+        .directive('rbFieldsetItem', rbFieldsetItemDirective);
 
     return rbFieldset;
 

--- a/src/rb-fieldset/rb-fieldset-item-directive.js
+++ b/src/rb-fieldset/rb-fieldset-item-directive.js
@@ -1,11 +1,11 @@
 define([
-    'html!./rb-fieldset.tpl.html'
+    'html!./rb-fieldset-item.tpl.html'
 ], function (template) {
 
     /**
      * @ngdoc directive
-     * @name rbFieldset
-     * @module rb-fieldset
+     * @name rbFieldsetItem
+     * @module rb-fieldset-item
      *
      * @restrict E
      *
@@ -13,18 +13,16 @@ define([
      *
      * @usage
      * <hljs lang="html">
-     *    <rb-fieldset>
-     *     </rb-fieldset>
+     *    <rb-fieldset-item>
+     *     </rb-fieldset-item>
      * </hljs>
      *
      * @ngInject
      */
-    function rbFieldsetDirective () {
+    function rbFieldsetItemDirective () {
 
         return {
             scope: {
-                label: '@',
-                type: '@'
             },
             restrict: 'E',
             replace: true,
@@ -33,5 +31,5 @@ define([
         };
     }
 
-    return rbFieldsetDirective;
+    return rbFieldsetItemDirective;
 });

--- a/src/rb-fieldset/rb-fieldset-item.tpl.html
+++ b/src/rb-fieldset/rb-fieldset-item.tpl.html
@@ -1,0 +1,1 @@
+<div class="Fieldset-item" ng-transclude></div>

--- a/src/rb-fieldset/rb-fieldset.tpl.html
+++ b/src/rb-fieldset/rb-fieldset.tpl.html
@@ -1,13 +1,19 @@
 <div class="Fieldset" ng-class="{
+    'Fieldset--actions': type == 'actions',
     'Fieldset--additionalInfo': type == 'additionalInfo',
     'Fieldset--basics': type == 'basics',
     'Fieldset--breakdown': type == 'breakdown',
-    'Fieldset--goals': type == 'goals',
     'Fieldset--finance': type == 'finance',
+    'Fieldset--goals': type == 'goals',
     'Fieldset--metrics': type == 'metrics'
 }">
     <div class="Fieldset-title">
         <span class="u-textLegend">{{ ::label }}</span>
     </div>
-    <div class="Fieldset-body" ng-transclude></div>
+
+    <div class="Fieldset-body" ng-if="type != 'actions'" ng-transclude></div>
+
+    <div class="Fieldset-body" ng-if="type == 'actions'">
+        <div class="Fieldset-items" ng-transclude></div>
+    </div>
 </div>

--- a/test/unit/rb-fieldset/rb-fieldset-item.spec.js
+++ b/test/unit/rb-fieldset/rb-fieldset-item.spec.js
@@ -1,0 +1,45 @@
+define([
+    'components/rb-fieldset'
+], function (rbFieldset) {
+    describe('rb-fieldset-item', function () {
+
+        var $rootScope,
+            $scope,
+            isolatedScope,
+            $compile,
+            element,
+            compileTemplate;
+
+        beforeEach(function () {
+
+            angular.mock.module(rbFieldset.name);
+
+            inject(function (_$compile_, _$rootScope_) {
+                $rootScope = _$rootScope_;
+                $scope = _$rootScope_.$new({});
+                $compile = _$compile_;
+
+                // Compile directive, apply scope and fetch new isolated scope
+                compileTemplate = function (template) {
+                    element = $compile(template)($scope);
+                    $scope.$apply();
+                    isolatedScope = element.isolateScope();
+                };
+            });
+        });
+
+        describe('rendering', function () {
+            it('should have appropriate SUIT class set', function () {
+                compileTemplate('<rb-fieldset-item></rb-fieldset-item>');
+
+                expect(element.hasClass('Fieldset-item')).toBe(true);
+            });
+
+            it('should render transcluded element', function () {
+                compileTemplate('<rb-fieldset-item><span>Buttons!</span></rb-fieldset-item>');
+
+                expect(element.html()).toContain('Buttons!');
+            });
+        });
+    });
+});

--- a/test/unit/rb-fieldset/rb-fieldset.spec.js
+++ b/test/unit/rb-fieldset/rb-fieldset.spec.js
@@ -85,6 +85,12 @@ define([
 
                 expect(element.hasClass('Fieldset--metrics')).toBeTruthy();
             });
+
+            it('should use the actions type', function () {
+                compileTemplate('<rb-fieldset label="Default Text" type="actions"></rb-fieldset>');
+
+                expect(element.hasClass('Fieldset--actions')).toBeTruthy();
+            });
         });
     });
 });


### PR DESCRIPTION
- `<rb-fieldset type="actions"></rb-fieldset>` will allow the use of field set items via `transclude`.
- `rb-fieldset-item` subcomponent directive.

TP: https://rockabox.tpondemand.com/entity/10097