### PR TITLE
Add `panel-scroll` `unscrollable` modifier

### DIFF
--- a/src/rb-panel-scroll/index.js
+++ b/src/rb-panel-scroll/index.js
@@ -3,10 +3,11 @@ define([
     './rb-panel-scroll-bottom-directive',
     './rb-panel-scroll-scrollable-directive',
     './rb-panel-scroll-top-directive',
+    './rb-panel-scroll-unscrollable-directive',
     './rb-panel-scroll.css'
 ], function (
         rbPanelScrollDirective, rbPanelScrollBottomDirective, rbPanelScrollScrollableDirective,
-        rbPanelScrollTopDirective, css) {
+        rbPanelScrollTopDirective, rbPanelScrollUnscrollableDirective, css) {
     /**
      * @ngdoc module
      * @name rb-panel-scroll
@@ -20,7 +21,8 @@ define([
         .directive('rbPanelScroll', rbPanelScrollDirective)
         .directive('rbPanelScrollBottom', rbPanelScrollBottomDirective)
         .directive('rbPanelScrollScrollable', rbPanelScrollScrollableDirective)
-        .directive('rbPanelScrollTop', rbPanelScrollTopDirective);
+        .directive('rbPanelScrollTop', rbPanelScrollTopDirective)
+        .directive('rbPanelScrollUnscrollable', rbPanelScrollUnscrollableDirective);
 
     return rbPanelScroll;
 

--- a/src/rb-panel-scroll/rb-panel-scroll-unscrollable-directive.js
+++ b/src/rb-panel-scroll/rb-panel-scroll-unscrollable-directive.js
@@ -1,0 +1,35 @@
+define([
+    'html!./rb-panel-scroll-unscrollable.tpl.html'
+], function (template) {
+
+    /**
+     * @ngdoc directive
+     * @name rbPanelScrollUnscrollable
+     * @module rb-panel-scroll-unscrollable
+     *
+     * @restrict E
+     *
+     * @description
+     *
+     * @usage
+     * <hljs lang="html">
+     *    <rb-panel-scroll-unscrollable>
+     *     </rb-panel-scroll-unscrollable>
+     * </hljs>
+     *
+     * @ngInject
+     */
+    function rbPanelScrollUnscrollableDirective () {
+
+        return {
+            scope: {
+            },
+            restrict: 'E',
+            replace: true,
+            template: template,
+            transclude: true
+        };
+    }
+
+    return rbPanelScrollUnscrollableDirective;
+});

--- a/src/rb-panel-scroll/rb-panel-scroll-unscrollable.tpl.html
+++ b/src/rb-panel-scroll/rb-panel-scroll-unscrollable.tpl.html
@@ -1,0 +1,1 @@
+<div class="PanelScroll-unscrollable" ng-transclude></div>

--- a/src/rb-panel-scroll/rb-panel-scroll.css
+++ b/src/rb-panel-scroll/rb-panel-scroll.css
@@ -18,3 +18,7 @@
     flex: 1;
     overflow: auto;
 }
+
+.PanelScroll-unscrollable {
+    flex: 1;
+}

--- a/test/unit/rb-panel-scroll/rb-panel-scroll.spec.js
+++ b/test/unit/rb-panel-scroll/rb-panel-scroll.spec.js
@@ -61,6 +61,18 @@ define([
             });
         });
 
+        describe('compiled `rb-panel-scroll-unscrollable` template', function () {
+            it('should contain a root element with the appropriate SUIT class', function () {
+                compileTemplate('<rb-panel-scroll-unscrollable></rb-panel-scroll-unscrollable>');
+                expect(element.hasClass('PanelScroll-unscrollable')).toBe(true);
+            });
+
+            it('should transclude content', function () {
+                compileTemplate('<rb-panel-scroll-unscrollable>My Content</rb-panel-scroll-unscrollable>');
+                expect(element.html()).toContain('My Content');
+            });
+        });
+
         describe('compiled `rb-panel-scroll-top` template', function () {
             it('should contain a root element with the appropriate SUIT class', function () {
                 compileTemplate('<rb-panel-scroll-top></rb-panel-scroll-top>');


### PR DESCRIPTION
Set up a middle flex area that fills available height but is unscrollable, so the transcluded components can
look after their own scroll themselves.

The naming is getting a bit silly with this: to be refactored.