### PR TITLE
Add default link style to `raw-html-display` component

### DIFF
--- a/src/rb-raw-html-display/rb-raw-html-display.css
+++ b/src/rb-raw-html-display/rb-raw-html-display.css
@@ -75,6 +75,21 @@
 }
 
 /**
+ * Link
+ */
+
+.RawHtmlDisplay a {
+    color: var(--color-base-link-default);
+}
+
+.RawHtmlDisplay a:hover,
+.RawHtmlDisplay a:focus,
+.RawHtmlDisplay a:active {
+    color: var(--color-base-link-hover);
+}
+
+
+/**
  * Blockquote
  */
 


### PR DESCRIPTION
No TP.

Makes links pretty; mirrors styles in `.u-linkClean` utility.