### PR TITLE
Fix `overlay-panel` close button position in Firefox

### DIFF
--- a/src/rb-overlay-panel/rb-overlay-panel.css
+++ b/src/rb-overlay-panel/rb-overlay-panel.css
@@ -25,6 +25,7 @@
 .OverlayPanel-close {
     left: 85%;
     position: absolute;
+    top: 0;
 }
 
 .OverlayPanel-button {


### PR DESCRIPTION
TP: https://rockabox.tpondemand.com/entity/10478

Adding `top: 0` on the close container forces button to top.

From:

![screenshot 2015-07-15 16 30 47](https://cloud.githubusercontent.com/assets/41568/8702378/55753368-2b0f-11e5-917c-9af285d5983f.png)

To: 

![screenshot 2015-07-15 16 30 55](https://cloud.githubusercontent.com/assets/41568/8702383/5c6f7aa2-2b0f-11e5-90fd-0bee15c9353c.png)
