### PR TITLE
Align campaign basic icon

### DIFF
--- a/src/rb-fieldset/images/basics.svg
+++ b/src/rb-fieldset/images/basics.svg
@@ -1,1 +1,1 @@
-<svg width="16" height="10" viewBox="0 0 16 10" xmlns="http://www.w3.org/2000/svg"><title>campaign-basics</title><path d="M4 10V8h12v2H4zm0-6h12v2H4V4zm0-4h12v2H4V0zM0 8h2v2H0V8zm0-4h2v2H0V4zm0-4h2v2H0V0z" fill="#35353A" fill-rule="evenodd"/></svg>
+<svg width="16" height="16" viewBox="0 0 16 10" xmlns="http://www.w3.org/2000/svg"><title>campaign-basics</title><path d="M4 10V8h12v2H4zm0-6h12v2H4V4zm0-4h12v2H4V0zM0 8h2v2H0V8zm0-4h2v2H0V4zm0-4h2v2H0V0z" fill="#35353A" fill-rule="evenodd"/></svg>


### PR DESCRIPTION
TP: https://rockabox.tpondemand.com/entity/10715

Makes the svg canvas the same size as other fieldset icons to nudge into alignment.