### PR TITLE
Fix `panel-scroll` `unscrollable` Firefox bug

### DIFF
--- a/src/rb-panel-content/rb-panel-content.css
+++ b/src/rb-panel-content/rb-panel-content.css
@@ -6,6 +6,8 @@
 
 /**
  * 1. Set to viewport height (we can do this as overlay panel uses full viewport height).
+ * 2. Fix implied `min-height` in Firefox. Affects contained components that manage their own overflow.
+ *      See: http://stackoverflow.com/a/26916542/2270732
  */
 
 .PanelContent {
@@ -22,4 +24,5 @@
 .PanelContent-unscrollable {
     display: flex;
     flex: 1;
+    min-height: 0;
 }


### PR DESCRIPTION
TP: https://rockabox.tpondemand.com/entity/10811

Only affects `rb-scrollspy` at time of fix (so test using `rb-scrollspy` either in ui_components or in an application).

Setting a `min-height: 0;` on the `unscrollable` directive fixes broken scrolling of child components in Firefox.

See: http://stackoverflow.com/a/26916542/2270732