### PR TITLE
Fix `rb-side-nav` background repeat MS Edge bug

### DIFF
--- a/src/rb-side-nav/rb-side-nav.css
+++ b/src/rb-side-nav/rb-side-nav.css
@@ -37,7 +37,8 @@
 }
 
 .SideNav-item {
-    background: var(--SideNav-background) url("./images/arrow.svg") no-repeat calc(100% - var(--SideNav-gutter)) center;
+    background: var(--SideNav-background) url("./images/arrow.svg") calc(100% - var(--SideNav-gutter)) center;
+    background-repeat: no-repeat;
     padding: 0.75em var(--SideNav-gutter);
 }
 


### PR DESCRIPTION
TP: https://rockabox.tpondemand.com/entity/10834

Add explicit `no-repeat` to background fixes Edge's seemingly weird parsing of background rules.

You will either need [Edge](http://www.microsoft.com/en-us/windows/microsoft-edge) or a [BrowserStack](http://www.browserstack.com/) account to review this.