### PR TITLE
Tab directive was incorrectly capturing all clicks within transcluded component.

### DIFF
--- a/src/rb-tabs/demo/demo.tpl.html
+++ b/src/rb-tabs/demo/demo.tpl.html
@@ -51,10 +51,10 @@
                 </rb-tabset>
             </rb-component-display>
         </rb-section>
-        <rb-section heading="With ui-sref set and link to somewhere else">
+        <rb-section heading="With rb-tab-sref set and link to somewhere else">
             <rb-component-display>
                 <rb-tabset>
-                    <rb-tab heading="Tab 1" ui-sref="rb-tabs">
+                    <rb-tab heading="Tab 1" rb-tab-sref="rb-tabs">
                         Lorem ipsum dolor sit amet, ut eam nullam utroque liberavisse, ea
                         graecis tractatos contentiones quo. Ipsum phaedrum scripserit sit id,
                         eu insolens indoctum vel, eos eu offendit delectus tincidunt. Eum
@@ -63,10 +63,10 @@
                         omnis temporibus cu mei. Legere scriptorem voluptatibus et est, ea
                         noluisse deterruisset sea.
                     </rb-tab>
-                    <rb-tab heading="Tab 2" ui-sref="rb-site">
+                    <rb-tab heading="Tab 2" rb-tab-sref="rb-site">
                         Just another tab!
                     </rb-tab>
-                    <rb-tab heading="Tab 3" ui-sref="rb-button">
+                    <rb-tab heading="Tab 3" rb-tab-sref="rb-button">
                         <h1>hello world dwodo</h1>
                     </rb-tab>
                 </rb-tabset>

--- a/src/rb-tabs/rb-tab-directive.js
+++ b/src/rb-tabs/rb-tab-directive.js
@@ -30,7 +30,7 @@ define([
             scope: {
                 heading: '@',
                 isActive: '=?',
-                uiSref: '@'
+                rbTabSref: '@'
             },
             link: function (scope, elem, attr, tabsetCtrl) {
                 if (angular.isUndefined(scope.isActive)) {

--- a/src/rb-tabs/rb-tabset.tpl.html
+++ b/src/rb-tabs/rb-tabset.tpl.html
@@ -1,8 +1,8 @@
 <div class="Tabs">
-    <ul class="Tabs-items" >
-        <li class="Tabs-item" ng-repeat="tab in tabset.tabs" ng-class="{'active': tab.active}">
-            <a ng-if="tab.uiSref" class="Tabs-itemInner"  ui-sref="{{tab.uiSref}}">{{::tab.heading}}</a>
-            <a ng-if="!tab.uiSref" class="Tabs-itemInner" ng-click="tabset.select(tab)">{{::tab.heading}}</a>
+    <ul class="Tabs-items">
+        <li class="Tabs-item" ng-repeat="tab in tabset.tabs" ui-sref-active="active">
+            <a ng-if="tab.rbTabSref" class="Tabs-itemInner"  ui-sref="{{tab.rbTabSref}}">{{::tab.heading}}</a>
+            <a ng-if="!tab.rbTabSref" class="Tabs-itemInner" ng-click="tabset.select(tab)">{{::tab.heading}}</a>
         </li>
     </ul>
     <ng-transclude class="Tabs-body"></ng-transclude>

--- a/test/unit/rb-tabs/rb-tabs.spec.js
+++ b/test/unit/rb-tabs/rb-tabs.spec.js
@@ -91,9 +91,9 @@ define([
 
             });
 
-            it('ui-sref should send the correct state name to the corrosponding tab scope', function () {
+            it('rb-tab-sref should send the correct state name to the corrosponding tab scope', function () {
                 template = '<rb-tabset>' +
-                                '<rb-tab heading="hello" ui-sref="rb-site">tab content</rb-tab>' +
+                                '<rb-tab heading="hello" rb-tab-sref="rb-site">tab content</rb-tab>' +
                                 '<rb-tab heading="tab2">tab2 content</rb-tab>' +
                                 '<rb-tab heading="tab3">tab3 content</rb-tab>' +
                             '</rb-tabset>';
@@ -101,7 +101,7 @@ define([
                 $scope.$apply();
                 var ctrl = $scope.$$childTail.tabset,
                     tabs = ctrl.tabs;
-                expect(tabs[0].uiSref).toBe('rb-site');
+                expect(tabs[0].rbTabSref).toBe('rb-site');
             });
 
         });


### PR DESCRIPTION
Tab directive was incorrectly capturing all clicks within transcluded directive. renamed component to prevent this and updated all the demos and documentation.