### PR TITLE
Remove redundant comments in `rb-generic-form styles

### DIFF
--- a/src/rb-generic-form/rb-generic-form.css
+++ b/src/rb-generic-form/rb-generic-form.css
@@ -5,10 +5,6 @@
  * rb-login-form) and should not use this component.
  */
 
-/**
- * 1. Inline button group.
- * 2. Match fieldset spacing.
- */
 .GenericForm {
     max-width: 60em;
 }


### PR DESCRIPTION
No TP.

Parts removed in a refactor, comments were left behind.