### PR TITLE
Move form width bounding rules

### DIFF
--- a/src/rb-fieldset/rb-fieldset.css
+++ b/src/rb-fieldset/rb-fieldset.css
@@ -16,14 +16,16 @@
 /**
  * 1. Linearize for small viewports, columnify label and body.
  * 2. Fieldset is technically a sectioning component, so margins allowed.
- * 3. Account for exciting default legend positioning.
- * 4. Remove border when using actions modifier.
+ * 3. Bound with max-width.
+ * 4. Account for exciting default legend positioning.
+ * 5. Remove border when using actions modifier.
  */
 
 .Fieldset {
     display: flex;
     flex-direction: column; /* 1 */
     margin-bottom: 2.5em; /* 2 */
+    max-width: 60em; /* 3 */
 }
 
 @media (--md-viewport) {
@@ -38,7 +40,7 @@
 
 .Fieldset-title {
     margin-top: 1.25em;
-    padding-top: 0.25em; /* 3 */
+    padding-top: 0.25em; /* 4 */
 }
 
 @media (--md-viewport) {
@@ -137,13 +139,13 @@
  */
 
 .Fieldset--actions .Fieldset-body {
-    border: 0; /* 4 */
+    border: 0; /* 5 */
 }
 
 @media (--md-viewport) {
 
     .Fieldset--actions .Fieldset-body {
-        border: 0; /* 4 */
+        border: 0; /* 5 */
     }
 
 }

--- a/src/rb-generic-form/rb-generic-form.css
+++ b/src/rb-generic-form/rb-generic-form.css
@@ -5,10 +5,6 @@
  * rb-login-form) and should not use this component.
  */
 
-.GenericForm {
-    max-width: 60em;
-}
-
 .GenericForm-message {
     font-size: var(--font-size-x-small);
     padding: 1em 0;


### PR DESCRIPTION
TP: https://rockabox.tpondemand.com/entity/10717

From `rb-generic-form` to `rb-fieldset`.

Setting upper bounds on form widths should ideally be done on a wrapper around the entire form, but this can't be done properly as forms have been split into two parts (the form itself and actions) and vary in use of other wrapper components.

Moving the bounding to fieldset-level is the least intrusive, next-best option.