### PR TITLE
Active tab not highlighted

### DIFF
--- a/src/rb-tabs/rb-tabset.tpl.html
+++ b/src/rb-tabs/rb-tabset.tpl.html
@@ -1,6 +1,8 @@
 <div class="Tabs">
     <ul class="Tabs-items">
-        <li class="Tabs-item" ng-repeat="tab in tabset.tabs" ui-sref-active="active">
+        <li class="Tabs-item" ng-repeat="tab in tabset.tabs" ui-sref-active="active" ng-class="{
+            'active': tab.active
+        }">
             <a ng-if="tab.rbTabSref" class="Tabs-itemInner"  ui-sref="{{tab.rbTabSref}}">{{::tab.heading}}</a>
             <a ng-if="!tab.rbTabSref" class="Tabs-itemInner" ng-click="tabset.select(tab)">{{::tab.heading}}</a>
         </li>

--- a/test/unit/rb-check-control/rb-check-control.spec.js
+++ b/test/unit/rb-check-control/rb-check-control.spec.js
@@ -111,7 +111,7 @@ define([
 
                 var label = element.find('label'),
                     icon = label.find('div');
-                console.log(icon);
+
                 expect(icon.hasClass('CheckControl-icon--mediaCentre')).toBe(true);
                 expect(icon.length).toBe(1);
             });

--- a/test/unit/rb-tabs/rb-tabs.spec.js
+++ b/test/unit/rb-tabs/rb-tabs.spec.js
@@ -75,20 +75,37 @@ define([
                 expect(tabs[2].active).toBe(true);
             });
 
-            it('is-active attribute should set the correct tab active', function () {
-                template = '<rb-tabset>' +
-                                '<rb-tab heading="hello" is-active="false">tab content</rb-tab>' +
-                                '<rb-tab heading="tab2" is-active="true">tab2 content</rb-tab>' +
-                                '<rb-tab heading="tab3" is-active="false">tab3 content</rb-tab>' +
-                            '</rb-tabset>';
-                ele = $compile(template)($scope);
-                $scope.$apply();
-                var ctrl = $scope.$$childTail.tabset,
-                    tabs = ctrl.tabs;
-                expect(tabs[0].active).toBe(false);
-                expect(tabs[1].active).toBe(true);
-                expect(tabs[2].active).toBe(false);
+            describe('is-active', function () {
+                var isActiveTmpl;
 
+                beforeEach(function () {
+                    isActiveTmpl = '<rb-tabset>' +
+                                    '<rb-tab heading="hello" is-active="false">tab content</rb-tab>' +
+                                    '<rb-tab heading="tab2" is-active="true">tab2 content</rb-tab>' +
+                                    '<rb-tab heading="tab3" is-active="false">tab3 content</rb-tab>' +
+                                '</rb-tabset>';
+                });
+
+                it('should set the correct tab active when set via attribute', function () {
+                    ele = $compile(isActiveTmpl)($scope);
+                    $scope.$apply();
+                    var ctrl = $scope.$$childTail.tabset,
+                        tabs = ctrl.tabs;
+                    expect(tabs[0].active).toBe(false);
+                    expect(tabs[1].active).toBe(true);
+                    expect(tabs[2].active).toBe(false);
+                });
+
+                it('should set class of active', function () {
+                    ele = $compile(isActiveTmpl)($scope);
+
+                    $scope.$apply();
+
+                    var tabs = ele[0].getElementsByClassName('Tabs-item');
+
+                    expect(angular.element(tabs[0]).hasClass('active')).toBeFalsy();
+                    expect(angular.element(tabs[1]).hasClass('active')).toBeTruthy();
+                });
             });
 
             it('rb-tab-sref should send the correct state name to the corrosponding tab scope', function () {


### PR DESCRIPTION
When using the option `is-active` with `rb-tab` it should set the class as active the same as `ui-sref-active` does.

TP: https://rockabox.tpondemand.com/entity/11401