### PR TITLE
Attribute transclusion and is-active attr

### DIFF
--- a/src/rg-header/demo/demo.tpl.html
+++ b/src/rg-header/demo/demo.tpl.html
@@ -27,7 +27,7 @@
             <rb-component-display>
                 <rb-header>
                     <rg-header color="blue">
-                        <rg-header-item href="">Create</rg-header-item>
+                        <rg-header-item href="" is-active="true">Create</rg-header-item>
                         <rg-header-item sref="">Distribute</rg-header-item>
                         <rg-header-item sref="">Analyse</rg-header-item>
                         <rg-header-user>
@@ -43,7 +43,7 @@
                 <rb-header>
                     <rg-header color="green">
                         <rg-header-item href="">Create</rg-header-item>
-                        <rg-header-item sref="">Distribute</rg-header-item>
+                        <rg-header-item sref="" is-active="true">Distribute</rg-header-item>
                         <rg-header-item sref="">Analyse</rg-header-item>
                         <rg-header-user>
                             <rg-header-user-item>Steve "Hats" Wozniak</rg-header-user-username>
@@ -59,7 +59,7 @@
                     <rg-header color="pink">
                         <rg-header-item href="">Create</rg-header-item>
                         <rg-header-item sref="">Distribute</rg-header-item>
-                        <rg-header-item sref="">Analyse</rg-header-item>
+                        <rg-header-item sref="" is-active="true">Analyse</rg-header-item>
                         <rg-header-user>
                             <rg-header-user-item>Steve "Hats" Wozniak</rg-header-user-username>
                             <rg-header-user-item ng-click="demoCtrl.logout()">Sign out</rg-header-user-item>

--- a/src/rg-header/rg-header-item-directive.js
+++ b/src/rg-header/rg-header-item-directive.js
@@ -1,6 +1,7 @@
 define([
-    'html!./rg-header-item.tpl.html'
-], function (template) {
+    'html!./rg-header-item.tpl.html',
+    'ui-components/utils/transclude-attrs'
+], function (template, transcludeAttrs) {
 
     /**
      * @ngdoc directive
@@ -24,6 +25,9 @@ define([
         return {
             scope: {
                 isActive: '@'
+            },
+            link: function (scope, elem, attrs) {
+                transcludeAttrs(elem, attrs, ['sref', 'href']);
             },
             restrict: 'E',
             replace: true,

--- a/src/rg-header/rg-header-item-directive.js
+++ b/src/rg-header/rg-header-item-directive.js
@@ -23,6 +23,7 @@ define([
 
         return {
             scope: {
+                isActive: '@'
             },
             restrict: 'E',
             replace: true,

--- a/src/rg-header/rg-header-item.tpl.html
+++ b/src/rg-header/rg-header-item.tpl.html
@@ -1,4 +1,4 @@
 <li class="RgHeader-navItem">
-    <a class="RgHeader-navItemInner" ng-transclude>
+    <a class="RgHeader-navItemInner" ng-transclude ng-class="{'is-active': isActive === 'true'}">
     </a>
 </li>

--- a/src/utils/transclude-attrs.js
+++ b/src/utils/transclude-attrs.js
@@ -1,0 +1,23 @@
+define([
+], function (
+) {
+    /**
+     * Move elements from root of a directive to whichever child element contains the `ng-transclude` directive.
+     *
+     * @param {object} elem - The angular element, generally passed from link or controller directive method
+     * @param {object} attrs - The angular attrs, generally passed from link or controller directive method
+     * @param {array} targetAttrs - A string array, containing names of the attributes to move
+     */
+    return function (elem, attrs, targetAttrs) {
+        var transcludeTarget = angular.element(elem[0].querySelectorAll('[ng-transclude]'));
+
+        angular.forEach(targetAttrs, function (targetAttr) {
+            if (angular.isDefined(attrs[targetAttr])) {
+                transcludeTarget.attr(targetAttr, attrs[targetAttr]);
+                elem.removeAttr(targetAttr);
+            }
+        });
+
+        return elem;
+    };
+});


### PR DESCRIPTION
- Add `is-active` toggle to `rg-header-item`
- `transcludeAttrs` method to move attrs to first child with `ng-transclude`
- Integrate `transcludeAttrs` on `rg-header-item` for `sref` and `href`

TP https://rockabox.tpondemand.com/entity/11496