### PR TITLE
New `RgSite` with composable stickiness

### DIFF
--- a/dev/app.js
+++ b/dev/app.js
@@ -49,6 +49,7 @@ define([
     'ui-components/rb-text-control/demo',
     'ui-components/rb-warning-messages/demo',
     'ui-components/rg-header/demo',
+    'ui-components/rg-site/demo',
     'ui-components/rg-text-control/demo',
     'rbx_style_guide'
 ], function (
@@ -102,6 +103,7 @@ define([
     rbTextControlDemo,
     rbWarningMessagesDemo,
     rgHeaderDemo,
+    rgSiteDemo,
     rgTextControlDemo,
     css
 ) {
@@ -157,6 +159,7 @@ define([
             rbTextControlDemo.name,
             rbWarningMessagesDemo.name,
             rgHeaderDemo.name,
+            rgSiteDemo.name,
             rgTextControlDemo.name
         ])
         .config(function ($stateProvider, $httpProvider) {

--- a/src/rb-main/demo/demo.tpl.html
+++ b/src/rb-main/demo/demo.tpl.html
@@ -24,15 +24,11 @@
                 </p>
                 <ul>
                     <li>
-                        <code>rb-main</code> must be a direct child of the <code><a ui-sref="rb-site">rb-site</a></code>
+                        <code>rb-main</code> must be a direct child of the <code><a ui-sref="rg-site">rg-site</a></code>
                         component.
                     </li>
                     <li>
                         <code>.Main--background</code> should not be used without also using <code>.Main--center</code>.
-                    </li>
-                    <li>
-                        When used, both <code>rb-header</code> and <code>rb-footer</code> must be direct children of the
-                        <code>rb-site</code> component.
                     </li>
                 </ul>
             </rb-raw-html-display>

--- a/src/rb-site/demo/demo.tpl.html
+++ b/src/rb-site/demo/demo.tpl.html
@@ -5,6 +5,9 @@
         <rb-section heading="Introduction" hide-heading="true">
             <rb-raw-html-display>
                 <p>
+                    <strong>DEPRECATED. Please use <code><a ui-sref="rg-site">rg-site</a></code>, which encompases functionality from this component.</strong>
+                </p>
+                <p>
                     The <code>rb-site</code> component should wrap all content on a page and is used in conjunction with
                     <code><a ui-sref="rb-main">rb-main</a></code> to create sticky footer and centred content effects.
                 </p>

--- a/src/rb-site/rb-site-directive.js
+++ b/src/rb-site/rb-site-directive.js
@@ -9,6 +9,9 @@ define([
      *
      * @restrict E
      *
+     * @deprecated
+     * Please use rg-site, which encompases functionality from this component.
+     *
      * @description
      * `<rb-site>` is a directive that wraps all content on a page
      *

--- a/src/rg-site/demo/demo-ctrl.js
+++ b/src/rg-site/demo/demo-ctrl.js
@@ -1,0 +1,10 @@
+define([
+], function () {
+
+    // @ngInject
+    function siteDemoCtrl () {
+
+    }
+
+    return siteDemoCtrl;
+});

--- a/src/rg-site/demo/demo-state.js
+++ b/src/rg-site/demo/demo-state.js
@@ -1,0 +1,15 @@
+define([
+    'html!./demo.tpl.html'
+], function (template) {
+
+    // @ngInject
+    function demoState ($stateProvider, $urlRouterProvider) {
+        $stateProvider.state('rg-site', {
+            url: '/rg-site',
+            controller: 'site-demo-ctrl as demoCtrl',
+            template: template
+        });
+    }
+
+    return demoState;
+});

--- a/src/rg-site/demo/demo.tpl.html
+++ b/src/rg-site/demo/demo.tpl.html
@@ -6,22 +6,99 @@
             <rb-raw-html-display>
                 <p>
                     The <code>rg-site</code> component should wrap all content on a page and is used in conjunction with
-                    <code><a ui-sref="rb-main">rb-main</a></code> to create sticky footer and centred content effects.
+                    the <code>rg-site-top</code> (top, sticky), <code>rg-site-middle</code> (middle, scrollable) and <code>rg-site-bottom</code> (bottom, sticky) descendents to create the desired layout.
+
+                    <code>rg-site-top</code> would ideally be used in conjunction with <code><a ui-sref='rb-main'>rb-main</a></code> to achieve centering content effects.
                 </p>
             </rb-raw-html-display>
         </rb-section>
-        <rb-section heading="Default">
+        <rb-section heading="Top, Middle and Bottom">
+            <rb-raw-html-display>
+                <p>
+                    Using all three subcomponents, the <code>rg-site-top</code> and <code>rg-site-bottom</code> sections will be sticky, and the scrollable <code>rg-site-middle</code> will fill the remainder of the space.
+                </p>
+            </rb-raw-html-display>
             <rb-component-display>
                 <rg-site>
-                    <rb-header>
-                        Header
-                    </rb-header>
-                    <rb-main class="Main--background Main--center">
-                        Main
-                    </rb-main>
-                    <rb-footer>
-                        Footer
-                    </rb-footer>
+                    <rg-site-top>
+                        <div>
+                            Header
+                        </div>
+                    </rg-site-top>
+                    <rg-site-middle>
+                        <rb-main class="Main--background Main--center">
+                            <div style="width: 25%; line-height:2em; padding: 5em;">
+                                <p>Bacon ipsum dolor amet andouille kielbasa doner tenderloin bresaola meatloaf shankle. Bacon pastrami picanha landjaeger ribeye jerky sausage kielbasa cupim ground round shank pork chop tenderloin shoulder pork. Turkey pastrami pig, pork loin beef shank filet mignon biltong hamburger andouille leberkas ham. Drumstick frankfurter meatball strip steak venison pancetta. Prosciutto fatback andouille turkey landjaeger spare ribs ham, sausage corned beef tenderloin. Bacon ham rump hamburger pastrami prosciutto short ribs tongue cupim boudin salami flank andouille kielbasa pancetta.</p>
+
+                                <p>Corned beef turducken filet mignon brisket capicola frankfurter beef ribs porchetta strip steak. Kielbasa biltong salami kevin sirloin turkey prosciutto alcatra picanha sausage drumstick. Shoulder venison pork loin pancetta kevin, ground round jowl meatloaf swine filet mignon frankfurter landjaeger tri-tip brisket meatball. Chuck turducken pork chop, bresaola bacon andouille landjaeger.</p>
+
+                                <p>Pork belly pork chop strip steak ground round porchetta pastrami short ribs shank rump ham salami filet mignon chuck pig bacon. Tri-tip hamburger biltong filet mignon pastrami kevin. Venison tongue pork loin, boudin pork belly filet mignon prosciutto turducken porchetta. Strip steak shankle jowl, bacon venison salami drumstick fatback hamburger capicola ham tenderloin picanha.</p>
+                            </div>
+                        </rb-main>
+                    </rg-site-middle>
+                    <rg-site-bottom>
+                        <div>
+                            Footer
+                        </div>
+                    </rg-site-bottom>
+                </rg-site>
+            </rb-component-display>
+        </rb-section>
+        <rb-section heading="Top and Middle">
+            <rb-raw-html-display>
+                <p>
+                    In this example, the footer content is placed in <code>rg-site-middle</code> and rather than sticking to the bottom of the viewport, it appears at the end of the middle content.
+                </p>
+            </rb-raw-html-display>
+            <rb-component-display>
+                <rg-site>
+                    <rg-site-top>
+                        <div>
+                            Header
+                        </div>
+                    </rg-site-top>
+                    <rg-site-middle>
+                        <rb-main class="Main--background Main--center">
+                            <div style="width: 25%; line-height:2em; padding: 5em;">
+                                <p>Bacon ipsum dolor amet andouille kielbasa doner tenderloin bresaola meatloaf shankle. Bacon pastrami picanha landjaeger ribeye jerky sausage kielbasa cupim ground round shank pork chop tenderloin shoulder pork. Turkey pastrami pig, pork loin beef shank filet mignon biltong hamburger andouille leberkas ham. Drumstick frankfurter meatball strip steak venison pancetta. Prosciutto fatback andouille turkey landjaeger spare ribs ham, sausage corned beef tenderloin. Bacon ham rump hamburger pastrami prosciutto short ribs tongue cupim boudin salami flank andouille kielbasa pancetta.</p>
+
+                                <p>Corned beef turducken filet mignon brisket capicola frankfurter beef ribs porchetta strip steak. Kielbasa biltong salami kevin sirloin turkey prosciutto alcatra picanha sausage drumstick. Shoulder venison pork loin pancetta kevin, ground round jowl meatloaf swine filet mignon frankfurter landjaeger tri-tip brisket meatball. Chuck turducken pork chop, bresaola bacon andouille landjaeger.</p>
+
+                                <p>Pork belly pork chop strip steak ground round porchetta pastrami short ribs shank rump ham salami filet mignon chuck pig bacon. Tri-tip hamburger biltong filet mignon pastrami kevin. Venison tongue pork loin, boudin pork belly filet mignon prosciutto turducken porchetta. Strip steak shankle jowl, bacon venison salami drumstick fatback hamburger capicola ham tenderloin picanha.</p>
+                            </div>
+                        </rb-main>
+                        <div>
+                            Footer
+                        </div>
+                    </rg-site-middle>
+                </rg-site>
+            </rb-component-display>
+        </rb-section>
+        <rb-section heading="Middle only">
+            <rb-raw-html-display>
+                <p>
+                    This time the header content is also placed in <code>rg-site-middle</code>. The header is now also no longer sticky, and will scroll out of the viewport as the middle content is scrolled.
+                </p>
+            </rb-raw-html-display>
+            <rb-component-display>
+                <rg-site>
+                    <rg-site-middle>
+                        <div>
+                            Header
+                        </div>
+                        <rb-main class="Main--background Main--center">
+                            <div style="width: 25%; line-height:2em; padding: 5em;">
+                                <p>Bacon ipsum dolor amet andouille kielbasa doner tenderloin bresaola meatloaf shankle. Bacon pastrami picanha landjaeger ribeye jerky sausage kielbasa cupim ground round shank pork chop tenderloin shoulder pork. Turkey pastrami pig, pork loin beef shank filet mignon biltong hamburger andouille leberkas ham. Drumstick frankfurter meatball strip steak venison pancetta. Prosciutto fatback andouille turkey landjaeger spare ribs ham, sausage corned beef tenderloin. Bacon ham rump hamburger pastrami prosciutto short ribs tongue cupim boudin salami flank andouille kielbasa pancetta.</p>
+
+                                <p>Corned beef turducken filet mignon brisket capicola frankfurter beef ribs porchetta strip steak. Kielbasa biltong salami kevin sirloin turkey prosciutto alcatra picanha sausage drumstick. Shoulder venison pork loin pancetta kevin, ground round jowl meatloaf swine filet mignon frankfurter landjaeger tri-tip brisket meatball. Chuck turducken pork chop, bresaola bacon andouille landjaeger.</p>
+
+                                <p>Pork belly pork chop strip steak ground round porchetta pastrami short ribs shank rump ham salami filet mignon chuck pig bacon. Tri-tip hamburger biltong filet mignon pastrami kevin. Venison tongue pork loin, boudin pork belly filet mignon prosciutto turducken porchetta. Strip steak shankle jowl, bacon venison salami drumstick fatback hamburger capicola ham tenderloin picanha.</p>
+                            </div>
+                        </rb-main>
+                        <div>
+                            Footer
+                        </div>
+                    </rg-site-middle>
                 </rg-site>
             </rb-component-display>
         </rb-section>

--- a/src/rg-site/demo/demo.tpl.html
+++ b/src/rg-site/demo/demo.tpl.html
@@ -1,0 +1,29 @@
+<rb-site>
+    <rb-main>
+        <rb-page-title heading="rb-site">
+        </rb-page-title>
+        <rb-section heading="Introduction" hide-heading="true">
+            <rb-raw-html-display>
+                <p>
+                    The <code>rg-site</code> component should wrap all content on a page and is used in conjunction with
+                    <code><a ui-sref="rb-main">rb-main</a></code> to create sticky footer and centred content effects.
+                </p>
+            </rb-raw-html-display>
+        </rb-section>
+        <rb-section heading="Default">
+            <rb-component-display>
+                <rg-site>
+                    <rb-header>
+                        Header
+                    </rb-header>
+                    <rb-main class="Main--background Main--center">
+                        Main
+                    </rb-main>
+                    <rb-footer>
+                        Footer
+                    </rb-footer>
+                </rg-site>
+            </rb-component-display>
+        </rb-section>
+    </rb-main>
+</rb-site>

--- a/src/rg-site/demo/index.js
+++ b/src/rg-site/demo/index.js
@@ -1,0 +1,12 @@
+define([
+    '../index.js',
+    './demo-ctrl',
+    './demo-state'
+], function (rgSite, demoCtrl, demoState) {
+    var demo = angular
+        .module('rg-site-demo', [rgSite.name])
+        .config(demoState)
+        .controller('site-demo-ctrl', demoCtrl);
+
+    return demo;
+});

--- a/src/rg-site/index.js
+++ b/src/rg-site/index.js
@@ -1,0 +1,18 @@
+define([
+    './rg-site-directive',
+    './rg-site.css'
+], function (rgSiteDirective, css) {
+    /**
+     * @ngdoc module
+     * @name rg-site
+     * @description
+     *
+     * RgSite
+     *
+     */
+    var rgSite = angular
+        .module('rg-site', [])
+        .directive('rgSite', rgSiteDirective);
+
+    return rgSite;
+});

--- a/src/rg-site/index.js
+++ b/src/rg-site/index.js
@@ -1,7 +1,16 @@
 define([
     './rg-site-directive',
+    './rg-site-top-directive',
+    './rg-site-middle-directive',
+    './rg-site-bottom-directive',
     './rg-site.css'
-], function (rgSiteDirective, css) {
+], function (
+    rgSiteDirective,
+    rgSiteTopDirective,
+    rgSiteMiddleDirective,
+    rgSiteBottomDirective,
+    css
+) {
     /**
      * @ngdoc module
      * @name rg-site
@@ -12,7 +21,10 @@ define([
      */
     var rgSite = angular
         .module('rg-site', [])
-        .directive('rgSite', rgSiteDirective);
+        .directive('rgSite', rgSiteDirective)
+        .directive('rgSiteTop', rgSiteTopDirective)
+        .directive('rgSiteMiddle', rgSiteMiddleDirective)
+        .directive('rgSiteBottom', rgSiteBottomDirective);
 
     return rgSite;
 });

--- a/src/rg-site/rg-site-bottom-directive.js
+++ b/src/rg-site/rg-site-bottom-directive.js
@@ -1,0 +1,37 @@
+define([
+    'html!./rg-site-bottom.tpl.html'
+], function (template) {
+
+    /**
+     * @ngdoc directive
+     * @name rgSiteBottom
+     * @module rg-site-bottom
+     *
+     * @restrict E
+     *
+     * @description
+     * `<rg-site-bottom>` is a directive that should be used inside rg-site, and sticks to the bottom of the page
+     *
+     * @usage
+     * <hljs lang="html">
+     *    <rg-site-bottom>
+     *        <any content>
+     *     </rg-site-bottom>
+     * </hljs>
+     *
+     * @ngInject
+     */
+    function rgSiteBottomDirective () {
+
+        return {
+            scope: {
+            },
+            restrict: 'E',
+            replace: true,
+            transclude: true,
+            template: template
+        };
+    }
+
+    return rgSiteBottomDirective;
+});

--- a/src/rg-site/rg-site-bottom.tpl.html
+++ b/src/rg-site/rg-site-bottom.tpl.html
@@ -1,0 +1,2 @@
+<div class="RgSite-bottom" ng-transclude>
+</div>

--- a/src/rg-site/rg-site-directive.js
+++ b/src/rg-site/rg-site-directive.js
@@ -1,0 +1,37 @@
+define([
+    'html!./rg-site.tpl.html'
+], function (template) {
+
+    /**
+     * @ngdoc directive
+     * @name rgSite
+     * @module rg-site
+     *
+     * @restrict E
+     *
+     * @description
+     * `<rg-site>` is a directive that wraps all content on a page
+     *
+     * @usage
+     * <hljs lang="html">
+     *    <rg-site>
+     *        <any content>
+     *     </rg-site>
+     * </hljs>
+     *
+     * @ngInject
+     */
+    function rgSiteDirective () {
+
+        return {
+            scope: {
+            },
+            restrict: 'E',
+            replace: true,
+            transclude: true,
+            template: template
+        };
+    }
+
+    return rgSiteDirective;
+});

--- a/src/rg-site/rg-site-middle-directive.js
+++ b/src/rg-site/rg-site-middle-directive.js
@@ -1,0 +1,37 @@
+define([
+    'html!./rg-site-middle.tpl.html'
+], function (template) {
+
+    /**
+     * @ngdoc directive
+     * @name rgSiteMiddle
+     * @module rg-site-middle
+     *
+     * @restrict E
+     *
+     * @description
+     * `<rg-site-middle>` is a directive that should be used inside rg-site, and fills the flex and is scrollable.
+     *
+     * @usage
+     * <hljs lang="html">
+     *    <rg-site-middle>
+     *        <any content>
+     *     </rg-site-middle>
+     * </hljs>
+     *
+     * @ngInject
+     */
+    function rgSiteMiddleDirective () {
+
+        return {
+            scope: {
+            },
+            restrict: 'E',
+            replace: true,
+            transclude: true,
+            template: template
+        };
+    }
+
+    return rgSiteMiddleDirective;
+});

--- a/src/rg-site/rg-site-middle.tpl.html
+++ b/src/rg-site/rg-site-middle.tpl.html
@@ -1,0 +1,2 @@
+<div class="RgSite-middle" ng-transclude>
+</div>

--- a/src/rg-site/rg-site-top-directive.js
+++ b/src/rg-site/rg-site-top-directive.js
@@ -1,0 +1,37 @@
+define([
+    'html!./rg-site-top.tpl.html'
+], function (template) {
+
+    /**
+     * @ngdoc directive
+     * @name rgSiteTop
+     * @module rg-site-top
+     *
+     * @restrict E
+     *
+     * @description
+     * `<rg-site-top>` is a directive that should be used inside rg-site, and sticks to the top of the page
+     *
+     * @usage
+     * <hljs lang="html">
+     *    <rg-site-top>
+     *        <any content>
+     *     </rg-site-top>
+     * </hljs>
+     *
+     * @ngInject
+     */
+    function rgSiteTopDirective () {
+
+        return {
+            scope: {
+            },
+            restrict: 'E',
+            replace: true,
+            transclude: true,
+            template: template
+        };
+    }
+
+    return rgSiteTopDirective;
+});

--- a/src/rg-site/rg-site-top.tpl.html
+++ b/src/rg-site/rg-site-top.tpl.html
@@ -1,0 +1,2 @@
+<div class="RgSite-top" ng-transclude>
+</div>

--- a/src/rg-site/rg-site.css
+++ b/src/rg-site/rg-site.css
@@ -2,8 +2,8 @@
 
 /**
  * The `.RgSite` class is generally attached to the `<body>` element.
- * Used to create Sticky Footer in conjunction with `.Main`.
- * See: http://philipwalton.github.io/solved-by-flexbox/demos/sticky-footer/
+ * Can be composed to create variants of stickiness using the `.RgSite-top`, `.RgSite-middle` and `.RgSite-bottom` descendents.
+ * Typically used in conjunction with `.Main`.
  */
 
 /**
@@ -13,5 +13,12 @@
 .RgSite {
     display: flex;
     flex-direction: column;
-    min-height: 100vh; /* 1 */
+    height: 100vh; /* 1 */
+}
+
+.RgSite-middle {
+    display: flex;
+    flex: 1;
+    flex-direction: column;
+    overflow-y: auto;
 }

--- a/src/rg-site/rg-site.css
+++ b/src/rg-site/rg-site.css
@@ -1,0 +1,17 @@
+/** @define RgSite; use strict */
+
+/**
+ * The `.RgSite` class is generally attached to the `<body>` element.
+ * Used to create Sticky Footer in conjunction with `.Main`.
+ * See: http://philipwalton.github.io/solved-by-flexbox/demos/sticky-footer/
+ */
+
+/**
+ * 1. Force height to 100% of viewport.
+ */
+
+.RgSite {
+    display: flex;
+    flex-direction: column;
+    min-height: 100vh; /* 1 */
+}

--- a/src/rg-site/rg-site.tpl.html
+++ b/src/rg-site/rg-site.tpl.html
@@ -1,0 +1,2 @@
+<div class="RgSite" ng-transclude>
+</div>

--- a/test/unit/rg-site/rg-site.spec.js
+++ b/test/unit/rg-site/rg-site.spec.js
@@ -1,0 +1,35 @@
+define([
+    'ui-components/rg-site'
+], function (rgSite) {
+    describe('rg-site', function () {
+
+        var $rootScope,
+            $scope,
+            isolatedScope,
+            $compile,
+            element,
+            compileTemplate;
+
+        beforeEach(angular.mock.module(rgSite.name));
+
+        beforeEach(inject(function (_$compile_, _$rootScope_) {
+            $rootScope = _$rootScope_;
+            $scope = _$rootScope_.$new({});
+            $compile = _$compile_;
+
+            // Compile directive, apply scope and fetch new isolated scope
+            compileTemplate = function (template) {
+                element = $compile(template)($scope);
+                $scope.$apply();
+                isolatedScope = element.isolateScope();
+            };
+        }));
+
+        describe('', function () {
+            it('should ', function () {
+                compileTemplate('<rg-site></rg-site>');
+            });
+        });
+
+    });
+});


### PR DESCRIPTION
Accidentally branched from previous branch, so please merge after https://github.com/rockabox/rbx_ui_components/pull/384

---

Three descendents enable this:

- `.RgSite-top`, sticks to top of viewport
- `.RgSite-bottom`, sticks to bottom of viewport
- `.RgSite-middle`, fills remainder of viewport

Depending on desired behaviour, content (i.e. Headers and Footers) can be moved between `top`, `middle` and `bottom`. See the demo for a full example.

TP https://rockabox.tpondemand.com/entity/11212