### PR TITLE
Transclude ui sref and remove logo link

### DIFF
--- a/src/rg-header/rg-header-item-directive.js
+++ b/src/rg-header/rg-header-item-directive.js
@@ -27,7 +27,7 @@ define([
                 isActive: '@'
             },
             link: function (scope, elem, attrs) {
-                transcludeAttrs(elem, attrs, ['sref', 'href']);
+                transcludeAttrs(elem, attrs, ['ui-sref', 'href']);
             },
             restrict: 'E',
             replace: true,

--- a/src/rg-header/rg-header.css
+++ b/src/rg-header/rg-header.css
@@ -53,7 +53,6 @@
     background-image: url("./images/logo-rockabox-blue.svg"); /* 1 */
     background-position: center;
     background-repeat: no-repeat;
-    cursor: pointer;
     margin: 0 var(--layout-gutter); /* 2 */
     margin-bottom: 0.5em; /* 3 */
     margin-top: 0.5em; /* 3 */

--- a/src/rg-header/rg-header.tpl.html
+++ b/src/rg-header/rg-header.tpl.html
@@ -1,5 +1,5 @@
 <div class="RgHeader {{ modifier }}" role="banner">
-    <a class="RgHeader-logo" ng-click="demoCtrl.logoHeaderFunction()" ng-aria>
+    <a class="RgHeader-logo" ng-aria>
         <div class="u-hiddenVisually">Rockabox</div>
     </a>
     <nav class="RgHeader-nav">


### PR DESCRIPTION
- Transclude `ui-sref`, not `sref` in `rg-header-item`
- Remove `ng-click` and `pointer` from `RgHeader-logo` as nowhere clear for it to go

TP https://rockabox.tpondemand.com/entity/11030