### PR TITLE
Fix `:-moz-ui-invalid` regression in `rg-text-control`

### DIFF
--- a/src/rg-text-control/rg-text-control.css
+++ b/src/rg-text-control/rg-text-control.css
@@ -75,6 +75,10 @@
     opacity: 1; /* 2 */
 }
 
+.RgTextControl-field:-moz-ui-invalid {
+    box-shadow: none;
+}
+
 .RgTextControl-field:focus,
 .RgTextControl-field.is-focused {
     border-color: var(--RgTextControl-field-focus-border-color);


### PR DESCRIPTION
No TP.

Prevent Firefox from displaying required fields with red box shadow.

This fix was introduced into `rb-text-control` but presumably after `rg-text-control` was cloned.