### PR TITLE
Repair `rb-side-nav` font size

### DIFF
--- a/src/rb-side-nav/rb-side-nav.css
+++ b/src/rb-side-nav/rb-side-nav.css
@@ -80,7 +80,7 @@
     color: var(--color-white-alabaster);
     display: inline-block;
     flex-shrink: 0;
-    font-size: var(--font-size-x-small);
+    font-size: var(--font-size-small);
     height: 0%; /* 1 */
     margin-left: auto;
     min-width: 23px;


### PR DESCRIPTION
No TP.

Looking for `var(--font-size-x-small)`, renamed to `var(--font-size-small)`.

Presume this got lost between icon fixes for `rb-side-nav` hanging around in stale branches while font sizes changes took place.