### PR TITLE
Add dynamic name to enable correct pairing of input to label tag

### DIFF
--- a/src/rb-check-control/rb-check-control-group.tpl.html
+++ b/src/rb-check-control/rb-check-control-group.tpl.html
@@ -34,7 +34,7 @@
     <div class="CheckControlGroup-body" ng-if="isDeviceChoice">
         <div ng-repeat="(key, value) in options">
             <rb-check-control
-                name="check-control-icon"
+                name="check-control-icon-{{::value.value}}"
                 label="{{::value.label}}"
                 icon="{{::value.value | lowercase}}"
                 ng-model="value.checked">


### PR DESCRIPTION
Add dynamic name to enable correct pairing of input to label tag. Previously clicking an icon within a label would not highlight (select) the right input.