### PR TITLE
Fix `rb-canvas` checkerboard background breakage

### DIFF
--- a/src/rb-canvas/rb-canvas.css
+++ b/src/rb-canvas/rb-canvas.css
@@ -15,6 +15,7 @@
     background: url("./images/checkered.svg");
     display: flex; /* 1 */
     flex-grow: 1;
+    height: 100%;
     justify-content: center; /* 1 */
     min-height: 2em;
     position: relative;


### PR DESCRIPTION
https://rockabox.tpondemand.com/entity/11520

Edge case: breaks with large creatives and small screens.

A slightly cheeky fix to work around an odd flexbox issue: step outside flex syntax and push the height of the canvas to 100%;