### PR TITLE
Allow adding of is-active instead of ui-router.

### DIFF
--- a/src/rg-header/rg-header-item.tpl.html
+++ b/src/rg-header/rg-header-item.tpl.html
@@ -2,7 +2,7 @@
     <a  class="RgHeader-navItemInner"
         ng-if="!rgUiSref"
         ui-sref-active="is-active"
-        ng-class="{'is-active' : isActive}"
+        ng-class="{'is-set-active' : isActive==='true'}"
         ng-attr-target="{{target || undefined}}"
         href="{{href}}"
         ng-transclude>
@@ -11,7 +11,7 @@
         ng-if="rgUiSref"
         ui-sref="{{rgUiSref}}"
         ui-sref-active="is-active"
-        ng-class="{'is-active' : isActive}"
+        ng-class="{'is-set-active' : isActive==='true'}"
         ng-attr-target="{{target || undefined}}"
         ng-transclude>
     </a>

--- a/src/rg-header/rg-header.css
+++ b/src/rg-header/rg-header.css
@@ -100,7 +100,8 @@
     color: var(--RgHeader-nav-color-hover);
 }
 
-.RgHeader-navItemInner.is-active {
+.RgHeader-navItemInner.is-active,
+.RgHeader-navItemInner.is-set-active {
     background: var(--RgHeader-nav-background-active);
     color: var(--RgHeader-nav-color-active);
 }
@@ -165,7 +166,8 @@
      * 1. Allow absolute positioning of `.is-active` state
      */
 
-    .RgHeader-navItemInner.is-active {
+    .RgHeader-navItemInner.is-active,
+    .RgHeader-navItemInner.is-set-active {
         position: relative; /* 1 */
     }
 
@@ -175,7 +177,8 @@
      * 4. Active indicator right arrow slant
      */
 
-    .RgHeader-navItemInner.is-active::after {
+    .RgHeader-navItemInner.is-active::after,
+    .RgHeader-navItemInner.is-set-active::after {
         border-bottom: var(--RgHeader-nav-is-active-arrow-size) solid var(--RgHeader-highlight-color); /* 1 */
         border-left: var(--RgHeader-nav-is-active-arrow-size) solid var(--color-transparent); /* 2 */
         border-right: var(--RgHeader-nav-is-active-arrow-size) solid var(--color-transparent); /* 3 */
@@ -201,7 +204,8 @@
     background-image: url("./images/logo-rockabox-blue.svg");
 }
 
-.RgHeader--blue .RgHeader-navItemInner.is-active::after {
+.RgHeader--blue .RgHeader-navItemInner.is-active::after,
+.RgHeader--blue .RgHeader-navItemInner.is-set-active::after {
     border-bottom-color: var(--RgHeader--blue-highlight-color);
 }
 
@@ -217,7 +221,8 @@
     background-image: url("./images/logo-rockabox-green.svg");
 }
 
-.RgHeader--green .RgHeader-navItemInner.is-active::after {
+.RgHeader--green .RgHeader-navItemInner.is-active::after,
+.RgHeader--green .RgHeader-navItemInner.is-set-active::after {
     border-bottom-color: var(--RgHeader--green-highlight-color);
 }
 
@@ -233,6 +238,7 @@
     background-image: url("./images/logo-rockabox-pink.svg");
 }
 
-.RgHeader--pink .RgHeader-navItemInner.is-active::after {
+.RgHeader--pink .RgHeader-navItemInner.is-active::after,
+.RgHeader--pink .RgHeader-navItemInner.is-set-active::after {
     border-bottom-color: var(--RgHeader--pink-highlight-color);
 }


### PR DESCRIPTION
Currently if you set something as `is-active` whilst using the `ui-router` it will be removed once you navigate away from the first page as `ui-router` will remove the class as the state isn't being used. 

This change allows `is-active` to be set outside of `ui-router` and will be used instead of `ui-router`.

TP: https://rockabox.tpondemand.com/entity/11693