### PR TITLE
Add isActive and $state to sidebar items to ensure they are resolved active if they should be. Adjust test to mock $state module.

### DIFF
--- a/src/rb-side-nav/rb-side-nav-item-directive.js
+++ b/src/rb-side-nav/rb-side-nav-item-directive.js
@@ -34,11 +34,12 @@ define([
      *
      * @ngInject
      */
-    function rbSideNavItemDirective () {
+    function rbSideNavItemDirective ($state) {
 
         return {
             scope: {
                 active: '=',
+                isActive: '@',
                 count: '=',
                 invalid: '=',
                 icon: '@',
@@ -48,7 +49,13 @@ define([
             },
             restrict: 'E',
             replace: true,
-            template: template
+            template: template,
+            link: function (scope) {
+                if ($state.current && scope.uiSref === $state.current.name) {
+                    // weird bug **created isActive to not conflict with existing active functionality
+                    scope.isActive = true;
+                }
+            }
         };
     }
 

--- a/src/rb-side-nav/rb-side-nav-item.tpl.html
+++ b/src/rb-side-nav/rb-side-nav-item.tpl.html
@@ -1,4 +1,5 @@
-<li class="SideNav-item SideNav-item--{{::icon}}" ng-class="{'is-active': active}">
+<li class="SideNav-item SideNav-item--{{::icon}}"
+    ng-class="{'is-active': active || isActive}">
     <a class="SideNav-itemInner" ui-sref="{{ ::uiSref }}">
         {{ ::label }}
         <span class="SideNav-status SideNav-status--count" ng-if="count && !invalid">{{ count }}</span>

--- a/test/unit/rb-side-nav/rb-side-nav-item.spec.js
+++ b/test/unit/rb-side-nav/rb-side-nav-item.spec.js
@@ -11,6 +11,18 @@ define([
             compileTemplate;
 
         beforeEach(angular.mock.module(rbSideNav.name));
+        beforeEach(angular.mock.module(function ($provide) {
+            // mock the entire $state provider
+            $provide.provider('$state', function () {
+                return {
+                    $get: function () {
+                        return {
+                            params: {}
+                        };
+                    }
+                };
+            });
+        }));
 
         beforeEach(inject(function (_$compile_, _$rootScope_) {
             $rootScope = _$rootScope_;


### PR DESCRIPTION
Add isActive and $state to sidebar items to ensure they are resolved active if they should be. Adjust test to mock $state module.

TP: https://rockabox.tpondemand.com/entity/11772