### PR TITLE
Fixes a bug where side nav is not full width of its cell.

### DIFF
--- a/src/rb-side-nav/rb-side-nav.css
+++ b/src/rb-side-nav/rb-side-nav.css
@@ -22,6 +22,7 @@
     background: var(--SideNav-background-color);
     height: 100vh;
     position: relative;
+    flex: 1;
 }
 
 .SideNav-heading {


### PR DESCRIPTION
When in a grid cell within the Overlay it should take the full width of it's parent setting as flex fixes this issue.

TP: https://rockabox.tpondemand.com/entity/12120