### PR TITLE
Fix an issue where select control placement is shown in safari.

### DIFF
--- a/src/rb-select-control/rb-select-control.tpl.html
+++ b/src/rb-select-control/rb-select-control.tpl.html
@@ -13,7 +13,7 @@
         ng-change="onChange({id:selected})"
         ng-disabled="{{ isDisabled }}"
         ng-required="{{ isRequired }}">
-            <option value="" ng-show="placeholder">{{ placeholder }}</option>
+            <option value="" ng-if="placeholder">{{ placeholder }}</option>
     </select>
     <select
         ng-show="isDynamicallyDisabled"
@@ -24,7 +24,7 @@
         ng-change="onChange({id:selected})"
         ng-disabled="isDynamicallyDisabled"
         ng-required="{{ isRequired }}">
-            <option value="" ng-show="placeholder">{{ placeholder }}</option>
+            <option value="" ng-if="placeholder">{{ placeholder }}</option>
     </select>
 
     <div class="SelectControl-message" ng-show="helpMessage">


### PR DESCRIPTION
`display: none` `option` will still show in safari. Changing this to `ng-if` will fix this.

(Tested for regression in rbx_campaign_management and rig_create)

TP: https://rockabox.tpondemand.com/entity/12125