### PR TITLE
Fix bug where switch components overlays the footer.

### DIFF
--- a/src/md-switch/custom-switch.css
+++ b/src/md-switch/custom-switch.css
@@ -1,0 +1,12 @@
+/** @define MdSwitch; use strict */
+
+/**
+ * The `md-switch` Angular Material component...
+ */
+
+/*
+ * Ensure that the md-switch doesn't overlay other components such as rb-footer
+ */
+md-switch .md-container {
+    z-index: 0;
+}

--- a/src/md-switch/index.js
+++ b/src/md-switch/index.js
@@ -3,8 +3,9 @@ define([
     'angular-material/checkbox/checkbox.js',
     'angular-material/checkbox/checkbox.css',
     'angular-material/switch/switch.js',
-    'angular-material/switch/switch.css'
-], function (rgMaterial, checkboxJs, checkboxCss, switchJs, switchCss) {
+    'angular-material/switch/switch.css',
+    './custom-switch.css'
+], function (rgMaterial, checkboxJs, checkboxCss, switchJs, switchCss, customSwitchCss) {
     var rgMatSelect = angular
         .module('md-switch', [
             rgMaterial.name,


### PR DESCRIPTION
Prevents a bug where the switch component would overlay the footer and other components due to z-index. 

![screen shot 2015-12-02 at 10 34 56](https://cloud.githubusercontent.com/assets/1407863/11533827/99d1e90e-9903-11e5-97a2-552d27e55a5e.png)

TP: https://rockabox.tpondemand.com/entity/12499