### PR TITLE
Bug fix minifed rb-text-control

### DIFF
--- a/src/rb-text-control/rb-text-control.tpl.html
+++ b/src/rb-text-control/rb-text-control.tpl.html
@@ -52,8 +52,8 @@
         ng-change="onChange({value:$parent.ngModel})"
         ng-class="{'is-invalid': form[name].$touched && form[name].$invalid}"
         custom-validation
-        msd-elastic="{{ isElastic || false }}"
-    />
+        msd-elastic="{{ isElastic || false }}">
+    </textarea>
 
     <div class="TextControl-message" ng-show="helpMessage">
         {{helpMessage}}


### PR DESCRIPTION
When minifying with html-minifier everything after `<textarea/>` is omitted as it is not valid HTML, this fixes the issue as a `<textarea>` can not be self closing by adding `</textarea>` also.

TP: https://rockabox.tpondemand.com/entity/12520